### PR TITLE
Ensure udev creates sym link for encyprted device

### DIFF
--- a/vaultlocker/dmcrypt.py
+++ b/vaultlocker/dmcrypt.py
@@ -84,3 +84,20 @@ def luks_open(key, uuid):
     subprocess.check_output(command,
                             input=key.encode('UTF-8'))
     return handle
+
+
+def udevadm_settle(uuid):
+    """udevadm settle the newly created encrypted device
+
+    Ensure udev has created symlink for newly created encyprted device.
+    See LP Bug #1780332
+
+    :param: uuid: uuid to use for encrypted block device.
+    """
+    logger.info('udevadm settle /dev/disk/by-uuid/{}'.format(uuid))
+    command = [
+        'udevadm',
+        'settle',
+        '--exit-if-exists=/dev/disk/by-uuid/{}'.format(uuid),
+    ]
+    subprocess.check_output(command)

--- a/vaultlocker/shell.py
+++ b/vaultlocker/shell.py
@@ -70,6 +70,9 @@ def _encrypt_block_device(args, client, config):
     vault_path = _get_vault_path(block_uuid, config)
 
     dmcrypt.luks_format(key, block_device, block_uuid)
+    # Ensure sym link for new encrypted device is created
+    # LP Bug #1780332
+    dmcrypt.udevadm_settle(block_uuid)
 
     # NOTE: store and validate key
     client.write(vault_path,


### PR DESCRIPTION
Vaultlocker was not ensuring that udev is triggered after the creation
of an encrypted device and failing on dmcrypt.luks_open.

This change implements Ryan Harper's advice to run udeavadm settle on
the new device uuid.

Closes-Bug: #1780332