### PR TITLE
Force rescan for block devices after luksFormat

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -7,4 +7,6 @@ encoding//vaultlocker/tests/functional/__init__.py=utf-8
 encoding//vaultlocker/tests/functional/base.py=utf-8
 encoding//vaultlocker/tests/functional/test_keystorage.py=utf-8
 encoding//vaultlocker/tests/unit/base.py=utf-8
+encoding//vaultlocker/tests/unit/test_dmcrypt.py=utf-8
+encoding//vaultlocker/tests/unit/test_systemd.py=utf-8
 encoding//vaultlocker/tests/unit/test_vaultlocker.py=utf-8

--- a/vaultlocker/dmcrypt.py
+++ b/vaultlocker/dmcrypt.py
@@ -86,6 +86,22 @@ def luks_open(key, uuid):
     return handle
 
 
+def udevadm_rescan():
+    """udevadm trigger for block device addition
+
+    Rescan for block devices to ensure that by-uuid devices are
+    created before use.
+    """
+    logger.info('udevadm trigger block/add')
+    command = [
+        'udevadm',
+        'trigger',
+        '--subsystem-match=block',
+        '--action=add'
+    ]
+    subprocess.check_output(command)
+
+
 def udevadm_settle(uuid):
     """udevadm settle the newly created encrypted device
 

--- a/vaultlocker/dmcrypt.py
+++ b/vaultlocker/dmcrypt.py
@@ -105,8 +105,8 @@ def udevadm_rescan():
 def udevadm_settle(uuid):
     """udevadm settle the newly created encrypted device
 
-    Ensure udev has created symlink for newly created encyprted device.
-    See LP Bug #1780332
+    Ensure udev has created the by-uuid symlink for newly
+    created encyprted device.
 
     :param: uuid: uuid to use for encrypted block device.
     """

--- a/vaultlocker/shell.py
+++ b/vaultlocker/shell.py
@@ -72,6 +72,7 @@ def _encrypt_block_device(args, client, config):
     dmcrypt.luks_format(key, block_device, block_uuid)
     # Ensure sym link for new encrypted device is created
     # LP Bug #1780332
+    dmcrypt.udevadm_rescan()
     dmcrypt.udevadm_settle(block_uuid)
 
     # NOTE: store and validate key

--- a/vaultlocker/tests/unit/test_dmcrypt.py
+++ b/vaultlocker/tests/unit/test_dmcrypt.py
@@ -59,3 +59,22 @@ class TestDMCrypt(base.TestCase):
         self.assertEqual(dmcrypt.generate_key(),
                          base64.b64encode(_key).decode('UTF-8'))
         _os.urandom.assert_called_with(dmcrypt.KEY_SIZE / 8)
+
+    @mock.patch.object(dmcrypt, 'subprocess')
+    def test_udevadm_rescan(self, _subprocess):
+        dmcrypt.udevadm_rescan()
+        _subprocess.check_output.assert_called_once_with(
+            ['udevadm',
+             'trigger',
+             '--subsystem-match=block',
+             '--action=add']
+        )
+
+    @mock.patch.object(dmcrypt, 'subprocess')
+    def test_udevadm_settle(self, _subprocess):
+        dmcrypt.udevadm_settle('myuuid')
+        _subprocess.check_output.assert_called_once_with(
+            ['udevadm',
+             'settle',
+             '--exit-if-exists=/dev/disk/by-uuid/myuuid']
+        )


### PR DESCRIPTION
Ensure that by-uuid devices are created for new LUKS devices
by forcing udev to rescan for block device addition.

This is probably a workaround for some sort of underlying bug
in the udev configuration for LUKS/dmcrypt, but it does
ensure that the subsequent luksOpen call works.