### PR TITLE
Specialize udevadm rescan to target block device

### DIFF
--- a/vaultlocker/dmcrypt.py
+++ b/vaultlocker/dmcrypt.py
@@ -86,17 +86,19 @@ def luks_open(key, uuid):
     return handle
 
 
-def udevadm_rescan():
+def udevadm_rescan(device):
     """udevadm trigger for block device addition
 
     Rescan for block devices to ensure that by-uuid devices are
     created before use.
+
+    :param: device: full path to block device to use.
     """
-    logger.info('udevadm trigger block/add')
+    logger.info('udevadm trigger block/add for {}'.format(device))
     command = [
         'udevadm',
         'trigger',
-        '--subsystem-match=block',
+        '--name-match={}'.format(device),
         '--action=add'
     ]
     subprocess.check_output(command)

--- a/vaultlocker/shell.py
+++ b/vaultlocker/shell.py
@@ -72,7 +72,7 @@ def _encrypt_block_device(args, client, config):
     dmcrypt.luks_format(key, block_device, block_uuid)
     # Ensure sym link for new encrypted device is created
     # LP Bug #1780332
-    dmcrypt.udevadm_rescan()
+    dmcrypt.udevadm_rescan(block_device)
     dmcrypt.udevadm_settle(block_uuid)
 
     # NOTE: store and validate key

--- a/vaultlocker/tests/unit/test_dmcrypt.py
+++ b/vaultlocker/tests/unit/test_dmcrypt.py
@@ -62,11 +62,11 @@ class TestDMCrypt(base.TestCase):
 
     @mock.patch.object(dmcrypt, 'subprocess')
     def test_udevadm_rescan(self, _subprocess):
-        dmcrypt.udevadm_rescan()
+        dmcrypt.udevadm_rescan('/dev/vdb')
         _subprocess.check_output.assert_called_once_with(
             ['udevadm',
              'trigger',
-             '--subsystem-match=block',
+             '--name-match=/dev/vdb',
              '--action=add']
         )
 


### PR DESCRIPTION
Limit the udevadm trigger call to only match the device being
used; this avoids rebuilding /dev/disk/by-*/* symlinks for all
block devices and the assocaited race conditions that might
exist when a system is under load.