### PR TITLE
Unblock network-online.target

### DIFF
--- a/tools/vaultlocker-decrypt@.service
+++ b/tools/vaultlocker-decrypt@.service
@@ -3,7 +3,6 @@ Description=vaultlocker retrieve: %i
 DefaultDependencies=no
 After=systemd-networkd-wait-online.service
 After=networking.service
-Before=network-online.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Drop "Before=network-online.target" from systemd unit to ensure
that vaultlocker-decrypt named units don't block boot; in
converged clouds where vault might be hosted on the same units
that are using it for key management this causes issues as the
LXD containers hosting vault won't be started until after
the vaultlocker-decrypt units complete, which won't ever happen.