### PR TITLE
Fixed error when calling app without arguments

### DIFF
--- a/vaultlocker/shell.py
+++ b/vaultlocker/shell.py
@@ -201,7 +201,10 @@ def main():
     logging.basicConfig(level=logging.DEBUG)
 
     try:
-        args.func(args, get_config())
+        if (len( vars(args) ) <= 2):
+            parser.print_help()
+        else:
+            args.func(args, get_config())
     except Exception as e:
         raise SystemExit(
             '{prog}: {msg}'.format(

--- a/vaultlocker/shell.py
+++ b/vaultlocker/shell.py
@@ -202,9 +202,9 @@ def main():
 
     try:
         if (len( vars(args) ) <= 2):
-            parser.print_help()
-        else:
-            args.func(args, get_config())
+            parser.print_help()
+        else:
+            args.func(args, get_config())
     except Exception as e:
         raise SystemExit(
             '{prog}: {msg}'.format(


### PR DESCRIPTION
This fix avoid "vaultlocker: 'Namespace' object has no attribute 'func'" error message when no arguments is passed to the app.