### PR TITLE
Remove systemd-networkd-wait-online

### DIFF
--- a/tools/vaultlocker-decrypt@.service
+++ b/tools/vaultlocker-decrypt@.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=vaultlocker retrieve: %i
 DefaultDependencies=no
-After=systemd-networkd-wait-online.service
 After=networking.service
 
 [Service]


### PR DESCRIPTION
On some hosts, it might be possible to have interfaces that are DOWN
with NO-CARRIER. In this case, systemd-networkd-wait-online will timeout
and fail. Therefore vaultlocker will also fail.
If vaultlocker fails it might impact the mount of the encrypted
partitions.