### PR TITLE
Remove py34 and add py37 test targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 before_install:
   - sudo -E bash ./gate/travis-vault.sh
 install:


### PR DESCRIPTION
Py34 is parallel to Trusty's py3, and the use case for
vaultlocker from the OpenStack product perspective is for
OpenStack Rocky and later, which will never use the py34
interpreter.  Further, one of the dependencies has removed
py34 support (python requests).

Add py37 test coverage.