### PR TITLE
Add dependency between nova-compute and vaultlocker

### DIFF
--- a/tools/vaultlocker-decrypt@.service
+++ b/tools/vaultlocker-decrypt@.service
@@ -2,6 +2,7 @@
 Description=vaultlocker retrieve: %i
 DefaultDependencies=no
 After=networking.service
+Before=nova-compute.service
 
 [Service]
 Type=oneshot
@@ -12,3 +13,5 @@ TimeoutSec=0
 
 [Install]
 WantedBy=multi-user.target
+RequiredBy=nova-compute.service
+


### PR DESCRIPTION
If vaultlocker fails to decrypt and mount
/var/lib/nova/instances, nova will start anyway
and may create instances with their disks on the
root filesystem's disk, which may not be encrypted.

This patch creates a dependency between the nova-compute
and vaultlocker services, so if vaultlocker fails
nova-compute will not be started.

Closes-bug: #1863358