### PR TITLE
Wait for dns to be configured

### DIFF
--- a/tools/vaultlocker-decrypt@.service
+++ b/tools/vaultlocker-decrypt@.service
@@ -2,6 +2,7 @@
 Description=vaultlocker retrieve: %i
 DefaultDependencies=no
 After=networking.service
+After=nss-lookup.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
A prior fix for bug 1838607 removed the wait
for networking to be configured which has had
the knock-on effect that if vaultlocker is
using hostnames instead of ipaddresses it will
not be able to resolve them if dns is not yet
configured. This patch adds After=nss-lookup.target
to ensure dns is configured prior to starting.

Closes-Bug: 1868557