### PR TITLE
Prevent encryption keys from being lost

### DIFF
--- a/vaultlocker/exceptions.py
+++ b/vaultlocker/exceptions.py
@@ -28,52 +28,34 @@ class VaultlockerException(Exception):
 class VaultWriteError(VaultlockerException):
 
     def __init__(self, path, error):
-        self.path = path
-        self.error = error
-
-    def __str__(self):
-        return "Can't write to vault at path {}, error: {}".format(
-            self.path, self.error)
+        super().__init__("Can't write to vault at path {}, error: {}".format(
+            path, error))
 
 
 class VaultReadError(VaultlockerException):
 
     def __init__(self, path, error):
-        self.path = path
-        self.error = error
-
-    def __str__(self):
-        return "Can't read vault at path {}, error: {}".format(
-            self.path, self.error)
+        super().__init__("Can't read vault at path {}, error: {}".format(
+            path, error))
 
 
 class VaultDeleteError(VaultlockerException):
 
     def __init__(self, path, error):
-        self.path = path
-        self.error = error
-
-    def __str__(self):
-        return "Can't delete vault key at path {}, error: {}".format(
-            self.path, self.error)
+        super().__init__("Can't delete vault key at path {}, error: {}".format(
+            path, error))
 
 
 class VaultKeyMismatch(VaultlockerException):
 
     def __init__(self, path):
-        self.path = path
-
-    def __str__(self):
-        return "Vault key at path {} does not match with generated key".format(
-            self.path)
+        super().__init__(
+            "Vault key at path {} does not match with generated key".format(
+                path))
 
 
 class LUKSFailure(VaultlockerException):
 
     def __init__(self, block_device, error):
-        self.block_device = block_device
-        self.error = error
-
-    def __str__(self):
-        return "Can't operate on {}. Error: {}".format(
-            self.block_device, self.error)
+        super().__init__("Can't operate on {}. Error: {}".format(
+            block_device, error))

--- a/vaultlocker/exceptions.py
+++ b/vaultlocker/exceptions.py
@@ -32,8 +32,8 @@ class VaultWriteError(VaultlockerException):
         self.error = error
 
     def __str__(self):
-        return "Can't write to vault at path {},\
-             error: {}".format(self.path, self.error)
+        return "Can't write to vault at path {}, error: {}".format(
+            self.path, self.error)
 
 
 class VaultReadError(VaultlockerException):
@@ -43,8 +43,8 @@ class VaultReadError(VaultlockerException):
         self.error = error
 
     def __str__(self):
-        return "Can't read vault at path {},\
-             error: {}".format(self.path, self.error)
+        return "Can't read vault at path {}, error: {}".format(
+            self.path, self.error)
 
 
 class VaultDeleteError(VaultlockerException):
@@ -54,8 +54,8 @@ class VaultDeleteError(VaultlockerException):
         self.error = error
 
     def __str__(self):
-        return "Can't delete vault key at path {},\
-             error: {}".format(self.path, self.error)
+        return "Can't delete vault key at path {}, error: {}".format(
+            self.path, self.error)
 
 
 class VaultKeyMismatch(VaultlockerException):
@@ -64,8 +64,8 @@ class VaultKeyMismatch(VaultlockerException):
         self.path = path
 
     def __str__(self):
-        return "Vault key at path {} does not match\
-             with generated key".format(self.path)
+        return "Vault key at path {} does not match with generated key".format(
+            self.path)
 
 
 class LUKSFailure(VaultlockerException):
@@ -75,5 +75,5 @@ class LUKSFailure(VaultlockerException):
         self.error = error
 
     def __str__(self):
-        return "Can't operate on {}.\
-             Error: {}".format(self.block_device, self.error)
+        return "Can't operate on {}. Error: {}".format(
+            self.block_device, self.error)

--- a/vaultlocker/shell.py
+++ b/vaultlocker/shell.py
@@ -23,8 +23,8 @@ import uuid
 from six.moves import configparser
 import subprocess
 from vaultlocker import dmcrypt
-from vaultlocker import systemd
 from vaultlocker import exceptions
+from vaultlocker import systemd
 
 logger = logging.getLogger(__name__)
 

--- a/vaultlocker/shell.py
+++ b/vaultlocker/shell.py
@@ -75,15 +75,16 @@ def _encrypt_block_device(args, client, config):
         client.write(vault_path,
                      dmcrypt_key=key)
     except hvac.exceptions.VaultError as write_error:
-        logger.error('Vault write to path {}. \
-            Failed with error:{}'.format(vault_path, write_error))
+        logger.error(
+            'Vault write to path {}. Failed with error:{}'.format(
+                vault_path, write_error))
         raise vault_exceptions.VaultWriteError(vault_path, write_error)
 
     try:
         stored_data = client.read(vault_path)
     except hvac.exceptions.VaultError as read_error:
-        logger.error('Vault access to path {} \
-            failed with error:{}'.format(vault_path, read_error))
+        logger.error('Vault access to path {}'
+                     'failed with error:{}'.format(vault_path, read_error))
         raise vault_exceptions.VaultReadError(vault_path, read_error)
 
     if not key == stored_data['data']['dmcrypt_key']:
@@ -100,9 +101,12 @@ def _encrypt_block_device(args, client, config):
         dmcrypt.udevadm_settle(block_uuid)
         dmcrypt.luks_open(key, block_uuid)
     except subprocess.CalledProcessError as luks_error:
-        logger.error('LUKS formatting {} failed with error code:{}\n\
-            LUKS output: {}'.format(block_device,
-                                    luks_error.returncode, luks_error.output))
+        logger.error(
+            'LUKS formatting {} failed with error code:{}\n'
+            'LUKS output: {}'.format(
+                block_device,
+                luks_error.returncode,
+                luks_error.output))
 
         try:
             client.delete(vault_path)

--- a/vaultlocker/shell.py
+++ b/vaultlocker/shell.py
@@ -24,7 +24,7 @@ from six.moves import configparser
 import subprocess
 from vaultlocker import dmcrypt
 from vaultlocker import systemd
-from vaultlocker import vault_exceptions
+from vaultlocker import exceptions
 
 logger = logging.getLogger(__name__)
 
@@ -78,17 +78,17 @@ def _encrypt_block_device(args, client, config):
         logger.error(
             'Vault write to path {}. Failed with error:{}'.format(
                 vault_path, write_error))
-        raise vault_exceptions.VaultWriteError(vault_path, write_error)
+        raise exceptions.VaultWriteError(vault_path, write_error)
 
     try:
         stored_data = client.read(vault_path)
     except hvac.exceptions.VaultError as read_error:
         logger.error('Vault access to path {}'
                      'failed with error:{}'.format(vault_path, read_error))
-        raise vault_exceptions.VaultReadError(vault_path, read_error)
+        raise exceptions.VaultReadError(vault_path, read_error)
 
     if not key == stored_data['data']['dmcrypt_key']:
-        raise vault_exceptions.VaultKeyMismatch(vault_path)
+        raise exceptions.VaultKeyMismatch(vault_path)
 
     # All function calls within try/catch raise a CalledProcessError
     # if return code is non-zero
@@ -111,9 +111,9 @@ def _encrypt_block_device(args, client, config):
         try:
             client.delete(vault_path)
         except hvac.exceptions.VaultError as del_error:
-            raise vault_exceptions.VaultDeleteError(vault_path, del_error)
+            raise exceptions.VaultDeleteError(vault_path, del_error)
 
-        raise vault_exceptions.LUKSFailure(block_device, luks_error.output)
+        raise exceptions.LUKSFailure(block_device, luks_error.output)
 
     systemd.enable('vaultlocker-decrypt@{}.service'.format(block_uuid))
 

--- a/vaultlocker/shell.py
+++ b/vaultlocker/shell.py
@@ -76,7 +76,7 @@ def _encrypt_block_device(args, client, config):
                      dmcrypt_key=key)
     except hvac.exceptions.VaultError as write_error:
         logger.error(
-            'Vault write to path {}. Failed with error:{}'.format(
+            'Vault write to path {}. Failed with error: {}'.format(
                 vault_path, write_error))
         raise exceptions.VaultWriteError(vault_path, write_error)
 
@@ -84,7 +84,7 @@ def _encrypt_block_device(args, client, config):
         stored_data = client.read(vault_path)
     except hvac.exceptions.VaultError as read_error:
         logger.error('Vault access to path {}'
-                     'failed with error:{}'.format(vault_path, read_error))
+                     'failed with error: {}'.format(vault_path, read_error))
         raise exceptions.VaultReadError(vault_path, read_error)
 
     if not key == stored_data['data']['dmcrypt_key']:
@@ -102,7 +102,7 @@ def _encrypt_block_device(args, client, config):
         dmcrypt.luks_open(key, block_uuid)
     except subprocess.CalledProcessError as luks_error:
         logger.error(
-            'LUKS formatting {} failed with error code:{}\n'
+            'LUKS formatting {} failed with error code: {}\n'
             'LUKS output: {}'.format(
                 block_device,
                 luks_error.returncode,

--- a/vaultlocker/tests/unit/test_vaultlocker.py
+++ b/vaultlocker/tests/unit/test_vaultlocker.py
@@ -24,7 +24,7 @@ import subprocess
 
 from vaultlocker import shell
 from vaultlocker.tests.unit import base
-from vaultlocker import vault_exceptions
+from vaultlocker import exceptions
 
 
 class TestVaultlocker(base.TestCase):
@@ -91,7 +91,7 @@ class TestVaultlocker(base.TestCase):
         }
 
         self.assertRaises(
-            vault_exceptions.VaultKeyMismatch,
+            exceptions.VaultKeyMismatch,
             shell._encrypt_block_device,
             args, client, self.config
         )
@@ -165,7 +165,7 @@ class TestVaultlocker(base.TestCase):
         }
 
         self.assertRaises(
-            vault_exceptions.LUKSFailure,
+            exceptions.LUKSFailure,
             shell._encrypt_block_device,
             args, client, self.config
         )

--- a/vaultlocker/tests/unit/test_vaultlocker.py
+++ b/vaultlocker/tests/unit/test_vaultlocker.py
@@ -22,9 +22,9 @@ Tests for `vaultlocker` module.
 import mock
 import subprocess
 
+from vaultlocker import exceptions
 from vaultlocker import shell
 from vaultlocker.tests.unit import base
-from vaultlocker import exceptions
 
 
 class TestVaultlocker(base.TestCase):

--- a/vaultlocker/tests/unit/test_vaultlocker.py
+++ b/vaultlocker/tests/unit/test_vaultlocker.py
@@ -20,9 +20,11 @@ Tests for `vaultlocker` module.
 """
 
 import mock
+import subprocess
 
 from vaultlocker import shell
 from vaultlocker.tests.unit import base
+from vaultlocker import vault_exceptions
 
 
 class TestVaultlocker(base.TestCase):
@@ -89,7 +91,7 @@ class TestVaultlocker(base.TestCase):
         }
 
         self.assertRaises(
-            AssertionError,
+            vault_exceptions.VaultKeyMismatch,
             shell._encrypt_block_device,
             args, client, self.config
         )
@@ -140,3 +142,32 @@ class TestVaultlocker(base.TestCase):
         _socket.gethostname.return_value = 'myhost'
         self.assertEqual(shell._get_vault_path('my-UUID', self.config),
                          'vaultlocker-test/myhost/my-UUID')
+
+    @mock.patch.object(shell, 'systemd')
+    @mock.patch.object(shell, 'dmcrypt')
+    @mock.patch.object(shell, '_get_vault_path')
+    def test_encrypt_luks_failure(self, _get_vault_path, _dmcrypt, _systemd):
+        _get_vault_path.return_value = 'backend/host/uuid'
+        _dmcrypt.generate_key.return_value = 'testkey'
+        _dmcrypt.luks_format.side_effect = \
+            subprocess.CalledProcessError(returncode=-1,
+                                          cmd="echo Unit Test")
+
+        args = mock.MagicMock()
+        args.uuid = 'passed-UUID'
+        args.block_device = ['/dev/sdb']
+
+        client = mock.MagicMock()
+        client.read.return_value = {
+            'data': {
+                'dmcrypt_key': 'testkey'
+            }
+        }
+
+        self.assertRaises(
+            vault_exceptions.LUKSFailure,
+            shell._encrypt_block_device,
+            args, client, self.config
+        )
+
+        client.delete.assert_called_once_with('backend/host/uuid')

--- a/vaultlocker/vault_exceptions.py
+++ b/vaultlocker/vault_exceptions.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+class VaultlockerException(Exception):
+
+    def __init__(self, *args):
+        if args:
+            self.message = args[0]
+        else:
+            self.message = "Empty VaultlockerException"
+
+    def __str__(self):
+        return self.message
+
+
+class VaultWriteError(VaultlockerException):
+
+    def __init__(self, path, error):
+        self.path = path
+        self.error = error
+
+    def __str__(self):
+        return "Can't write to vault at path {},\
+             error: {}".format(self.path, self.error)
+
+
+class VaultReadError(VaultlockerException):
+
+    def __init__(self, path, error):
+        self.path = path
+        self.error = error
+
+    def __str__(self):
+        return "Can't read vault at path {},\
+             error: {}".format(self.path, self.error)
+
+
+class VaultDeleteError(VaultlockerException):
+
+    def __init__(self, path, error):
+        self.path = path
+        self.error = error
+
+    def __str__(self):
+        return "Can't delete vault key at path {},\
+             error: {}".format(self.path, self.error)
+
+
+class VaultKeyMismatch(VaultlockerException):
+
+    def __init__(self, path):
+        self.path = path
+
+    def __str__(self):
+        return "Vault key at path {} does not match\
+             with generated key".format(self.path)
+
+
+class LUKSFailure(VaultlockerException):
+
+    def __init__(self, block_device, error):
+        self.block_device = block_device
+        self.error = error
+
+    def __str__(self):
+        return "Can't operate on {}.\
+             Error: {}".format(self.block_device, self.error)


### PR DESCRIPTION
Encryption key storage to Vault is attempted prior to encrypting the
disk. If any LUKS call fails within the encryption function, the key
is deleted from Vault and an exception is raised.

https://bugs.launchpad.net/vaultlocker/+bug/1818165