### PR TITLE
Added a key in the configuration file for alternative CA bundles

### DIFF
--- a/etc/vaultlocker.conf
+++ b/etc/vaultlocker.conf
@@ -3,3 +3,4 @@ url = http://10.5.0.13:8200
 approle = e256bf3b-fb28-b1d6-f2fb-3adc8339d3ad
 secret_id = 9428ad25-7b4a-442f-8f20-f23be0575146
 backend = secret
+#ca_bundle =

--- a/vaultlocker/shell.py
+++ b/vaultlocker/shell.py
@@ -38,7 +38,10 @@ def _vault_client(config):
     :param: config: configparser object of vaultlocker config
     :returns: hvac.Client. configured Vault Client object
     """
-    client = hvac.Client(url=config.get('vault', 'url'))
+    client = hvac.Client(
+        url=config.get('vault', 'url'),
+        verify=config.get('vault', 'ca_bundle', fallback=True)
+    )
     client.auth_approle(config.get('vault', 'approle'),
                         secret_id=config.get('vault', 'secret_id'))
     return client

--- a/vaultlocker/tests/functional/base.py
+++ b/vaultlocker/tests/functional/base.py
@@ -91,7 +91,7 @@ class VaultlockerFuncBaseTestCase(base.BaseTestCase):
         }
         self.config = mock.MagicMock()
         self.config.get.side_effect = \
-            lambda s, k: self.test_config.get(s).get(k)
+            lambda s, k, **kwargs: self.test_config.get(s).get(k)
 
     def tearDown(self):
         super(VaultlockerFuncBaseTestCase, self).tearDown()

--- a/vaultlocker/tests/unit/test_vaultlocker.py
+++ b/vaultlocker/tests/unit/test_vaultlocker.py
@@ -39,7 +39,10 @@ class TestVaultlocker(base.TestCase):
     def __init__(self, *args, **kwds):
         super(TestVaultlocker, self).__init__(*args, **kwds)
         self.config = mock.MagicMock()
-        self.config.get.side_effect = lambda _, k: self._test_config.get(k)
+
+        def side_effect(_, k, **kwargs):
+            return self._test_config.get(k)
+        self.config.get.side_effect = side_effect
 
     @mock.patch.object(shell, 'systemd')
     @mock.patch.object(shell, 'dmcrypt')


### PR DESCRIPTION
Hello,

This new PR allows users to use an alternative CA bundle to validate the SSL certificate of the target Hashicorp Vault instance.

This is useful for users who set up an Hashicorp Vault instance with a custom CA, but can't (or do not wish) to install a new trusted CA certificate in the SSL folder of the machine, for policy reasons.

This option is quite common on other tools / programs, such as:
* [Ansible Hashivault modules](https://terryhowe.github.io/ansible-modules-hashivault/modules/hashivault_read_module.html#parameter-ca_path)
* [cURL](https://curl.haxx.se/docs/manpage.html#--cacert)
* [pip](https://manpages.debian.org/jessie/python3-pip/pip3.1#GENERAL_OPTIONS) (the `--cert` flag)
* etc.

In this proposed PR, is the `ca_bundle` key is not given in the configuration file, the `verify` parameter defaults to `True`, [which is the current behaviour of the hvac client constructor](https://github.com/hvac/hvac/blob/develop/hvac/v1/__init__.py#L22).

If you have any remark / suggestion regarding this PR, I'm all ears!