### PR TITLE
Added check for presence of systemd unit file before encryption

### DIFF
--- a/vaultlocker/shell.py
+++ b/vaultlocker/shell.py
@@ -186,7 +186,14 @@ def encrypt(args, config):
     :param: args: argparser generated cli arguments
     :param: config: configparser object of vaultlocker config
     """
-    _do_it_with_persistence(_encrypt_block_device, args, config)
+    if (os.path.exists('/usr/lib/systemd/system/vaultlocker-decrypt@.service') or
+        os.path.exists('/etc/systemd/system/vaultlocker-decrypt@.service')):
+        _do_it_with_persistence(_encrypt_block_device, args, config)
+    else:
+        raise FileNotFoundError("""
+            Systemd Unit vaultlocker-encrypt@.service not found
+            in /usr/lib/systemd/system/ or /etc/systemd/system/
+            """)
 
 
 def decrypt(args, config):

--- a/vaultlocker/shell.py
+++ b/vaultlocker/shell.py
@@ -186,8 +186,10 @@ def encrypt(args, config):
     :param: args: argparser generated cli arguments
     :param: config: configparser object of vaultlocker config
     """
-    if (os.path.exists('/usr/lib/systemd/system/vaultlocker-decrypt@.service') or
-        os.path.exists('/etc/systemd/system/vaultlocker-decrypt@.service')):
+    if os.path.exists(
+        "/usr/lib/systemd/system/vaultlocker-decrypt@.service"
+    ) or os.path.exists(
+        "/etc/systemd/system/vaultlocker-decrypt@.service"):
         _do_it_with_persistence(_encrypt_block_device, args, config)
     else:
         raise FileNotFoundError("""

--- a/vaultlocker/tests/functional/test_keystorage.py
+++ b/vaultlocker/tests/functional/test_keystorage.py
@@ -38,7 +38,17 @@ class KeyStorageTestCase(base.VaultlockerFuncBaseTestCase):
         args.block_device = ['/dev/sdb']
         args.retry = -1
 
+        def mock_path_exists_side_effect(arg):
+            if arg in ['/usr/lib/systemd/system/vaultlocker-decrypt@.service',
+                       '/etc/systemd/system/vaultlocker-decrypt@.service']:
+                return True
+            else:
+                return False
+
+        mock_pathexists = mock.patch('os.path.exists').start()
+        mock_pathexists.side_effect = mock_path_exists_side_effect
         shell.encrypt(args, self.config)
+
         _luks_format.assert_called_once_with(mock.ANY,
                                              '/dev/sdb',
                                              'passed-UUID')


### PR DESCRIPTION
Hello,

This PR goal is to avoid eventual pitfalls in case Vaultlocker is installed in a virtualenv.
Indeed when installed this way, Vaultlocker won't have the `vaultlocker-decrypt@.service systemd` unit in neither `/usr/lib/systemd/system` nor `/etc/systemd/system`
This can be a problem, because if volumes are encrypted without this file present, they won't be decrypted automatically at boot (the user would have to manually run commands to do so).

In this PR, a check if performed before encrypting volumes. If the files are not found, a `FileNotFoundError` exception is raised. 

Open to any remarks or questions.