### PR TITLE
chore: tidy lint and unit test imports for py >= 3.8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,8 @@ commands = {posargs}
 basepython = python2.7
 commands = pifpaf run vault -- stestr run "^vaultlocker.tests.functional.*"
 
-[testenv:func36]
-basepython = python3.6
+[testenv:func3]
+basepython = python3
 commands = pifpaf run vault -- stestr run "^vaultlocker.tests.functional.*"
 
 [testenv:cover]

--- a/vaultlocker/tests/functional/base.py
+++ b/vaultlocker/tests/functional/base.py
@@ -16,8 +16,8 @@
 # under the License.
 
 import hvac
-import mock
 import os
+from unittest import mock
 import uuid
 
 from oslotest import base

--- a/vaultlocker/tests/functional/test_keystorage.py
+++ b/vaultlocker/tests/functional/test_keystorage.py
@@ -15,7 +15,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import mock
+from unittest import mock
 
 from vaultlocker import shell
 from vaultlocker.tests.functional import base
@@ -56,8 +56,8 @@ class KeyStorageTestCase(base.VaultlockerFuncBaseTestCase):
         )
         self.assertIsNotNone(stored_data,
                              'Key data missing from vault')
-        self.assertTrue('dmcrypt_key' in stored_data['data'],
-                        'dm-crypt key data is missing')
+        self.assertIn('dmcrypt_key', stored_data['data'],
+                      'dm-crypt key data is missing')
 
     def test_decrypt(self, _luks_open, _luks_format, _systemd,
                      _udevadm_rescan, _udevadm_settle):

--- a/vaultlocker/tests/unit/test_dmcrypt.py
+++ b/vaultlocker/tests/unit/test_dmcrypt.py
@@ -20,7 +20,7 @@ Tests for `dmcrypt` module.
 """
 
 import base64
-import mock
+from unittest import mock
 
 from vaultlocker import dmcrypt
 from vaultlocker.tests.unit import base

--- a/vaultlocker/tests/unit/test_systemd.py
+++ b/vaultlocker/tests/unit/test_systemd.py
@@ -19,7 +19,7 @@ test_systemd
 Tests for `systemd` module.
 """
 
-import mock
+from unittest import mock
 
 from vaultlocker import systemd
 from vaultlocker.tests.unit import base

--- a/vaultlocker/tests/unit/test_vaultlocker.py
+++ b/vaultlocker/tests/unit/test_vaultlocker.py
@@ -19,8 +19,9 @@ test_vaultlocker
 Tests for `vaultlocker` module.
 """
 
-import mock
 import subprocess
+
+from unittest import mock
 
 from vaultlocker import exceptions
 from vaultlocker import shell


### PR DESCRIPTION
Misc tidy and fixes to resolve imports of mock under newer
python versions.