### PR TITLE
Support for newer versions of hvac

### DIFF
--- a/vaultlocker/shell.py
+++ b/vaultlocker/shell.py
@@ -42,7 +42,11 @@ def _vault_client(config):
         url=config.get('vault', 'url'),
         verify=config.get('vault', 'ca_bundle', fallback=True)
     )
-    client.auth_approle(config.get('vault', 'approle'),
+    if hasattr(client, 'auth_approle')
+        client.auth_approle(config.get('vault', 'approle'),
+                        secret_id=config.get('vault', 'secret_id'))
+    else
+        client.auth.approle.login(config.get('vault', 'approle'),
                         secret_id=config.get('vault', 'secret_id'))
     return client
 


### PR DESCRIPTION
The `client.auth_approle` has been deprecated on newer versions. This simple hack seems to work for both new and old ones.