### PR TITLE
Modernize vaultlocker for python 3.12+ and current hvac APIs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,5 +53,8 @@ jobs:
         run: |
           stestr run "^vaultlocker.tests.unit.*"
       - name: "run functional tests"
+        env:
+          PIFPAF_VAULT_ADDR: "http://127.0.0.1:8200"
+          PIFPAF_ROOT_TOKEN: "testing"
         run: |
           stestr run "^vaultlocker.tests.functional.*"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,30 +9,43 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python_versions:
-          - '3.6'
-          - '3.7'
-          - '3.8'
+        requirements:
+          - noble
+          - resolute
+          - latest
         vault_versions:
-          - '1.7.3'
-          - '1.1.5'
+          - '1.8'
+          - '1.18'
+          - '2.0'
+        include:
+          - requirements: noble
+            python_version: '3.12'
+          - requirements: resolute
+            python_version: '3.14'
+          - requirements: latest
+            python_version: '3.14'
     runs-on: ubuntu-latest
     services:
       vault:
-        image: vault:${{ matrix.vault_versions }}
+        image: hashicorp/vault:${{ matrix.vault_versions }}
         env:
           VAULT_DEV_ROOT_TOKEN_ID: "testing"
         ports:
           - 8200:8200
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python_versions }}
+          python-version: ${{ matrix.python_version }}
       - name: "install requirements"
         run: |
-          pip install -r requirements.txt -c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt
-          pip install -r test-requirements.txt -c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt
+          if [ "${{ matrix.requirements }}" = "latest" ]; then
+            pip install -r requirements.txt
+          else
+            pip install -r requirements-${{ matrix.requirements }}.txt
+          fi
+          pip install -r test-requirements.txt
+          pip install .
       - name: "flake8 run"
         run: |
           flake8

--- a/requirements-noble.txt
+++ b/requirements-noble.txt
@@ -1,0 +1,7 @@
+# Dependency versions available in noble.
+
+-r requirements.txt
+
+pbr==5.11.1
+hvac==0.11.2
+tenacity==8.2.3

--- a/requirements-resolute.txt
+++ b/requirements-resolute.txt
@@ -1,0 +1,7 @@
+# Dependency versions available in resolute.
+
+-r requirements.txt
+
+pbr==7.0.3
+hvac==2.3.0
+tenacity==9.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@
 # process, which may cause wedges in the gate later.
 
 pbr>=2.0 # Apache-2.0
-hvac
+hvac>=0.10.6 # client.auth.approle.login() requires this API
 tenacity

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ description-file =
 author = OpenStack Charms Team
 author-email = openstack-dev@lists.openstack.org
 home-page = http://www.openstack.org/
+python_requires = >=3.12
 classifier =
     Environment :: OpenStack
     Intended Audience :: Information Technology
@@ -13,10 +14,10 @@ classifier =
     License :: OSI Approved :: Apache Software License
     Operating System :: POSIX :: Linux
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
 
 [files]
 packages =

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
-minversion = 2.0
-envlist = py35,py36,py27,pep8
-skipsdist = True
+minversion = 4.0
+envlist = noble,resolute,latest,pep8
 skip_missing_interpreters = True
 
 [testenv]
 usedevelop = True
-install_command = pip install -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt} {opts} {packages}
 setenv =
    VIRTUAL_ENV={envdir}
    PYTHONWARNINGS=default::DeprecationWarning
@@ -16,15 +14,29 @@ setenv =
 deps = -r{toxinidir}/test-requirements.txt
 commands = stestr run "^vaultlocker.tests.unit.*" {posargs}
 
+[testenv:noble]
+basepython = python3.12
+deps =
+    -r{toxinidir}/requirements-noble.txt
+    -r{toxinidir}/test-requirements.txt
+
+[testenv:resolute]
+basepython = python3.14
+deps =
+    -r{toxinidir}/requirements-resolute.txt
+    -r{toxinidir}/test-requirements.txt
+
+[testenv:latest]
+basepython = python3.14
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
+
 [testenv:pep8]
 commands = flake8 {posargs}
 
 [testenv:venv]
 commands = {posargs}
-
-[testenv:func27]
-basepython = python2.7
-commands = pifpaf run vault -- stestr run "^vaultlocker.tests.functional.*"
 
 [testenv:func3]
 basepython = python3

--- a/vaultlocker/shell.py
+++ b/vaultlocker/shell.py
@@ -20,7 +20,7 @@ import socket
 import tenacity
 import uuid
 
-from six.moves import configparser
+import configparser
 import subprocess
 from vaultlocker import dmcrypt
 from vaultlocker import exceptions
@@ -42,8 +42,10 @@ def _vault_client(config):
         url=config.get('vault', 'url'),
         verify=config.get('vault', 'ca_bundle', fallback=True)
     )
-    client.auth_approle(config.get('vault', 'approle'),
-                        secret_id=config.get('vault', 'secret_id'))
+    client.auth.approle.login(
+        role_id=config.get('vault', 'approle'),
+        secret_id=config.get('vault', 'secret_id')
+    )
     return client
 
 

--- a/vaultlocker/tests/functional/base.py
+++ b/vaultlocker/tests/functional/base.py
@@ -21,7 +21,6 @@ from unittest import mock
 import uuid
 
 from oslotest import base
-from testtools import testcase
 
 
 TEST_POLICY = '''
@@ -48,37 +47,40 @@ class VaultlockerFuncBaseTestCase(base.BaseTestCase):
         self.vault_approle = 'vaultlocker-approle-{}'.format(self.test_uuid)
 
         if not self.vault_addr or not self.root_token:
-            raise testcase.TestSkipped('Vault not running')
+            self.skipTest('Vault not running')
 
         self.vault_client = hvac.Client(url=self.vault_addr,
                                         token=self.root_token)
 
-        self.vault_client.enable_secret_backend(
+        self.vault_client.sys.enable_secrets_engine(
             backend_type='kv',
-            description='vault test backend',
-            mount_point=self.vault_backend
+            path=self.vault_backend,
+            description='vaultlocker test backend',
+            options={'version': '1'},
         )
 
         try:
-            self.vault_client.enable_auth_backend('approle')
+            self.vault_client.sys.enable_auth_method('approle')
         except hvac.exceptions.InvalidRequest:
             pass
 
-        self.vault_client.set_policy(
+        self.vault_client.sys.create_or_update_policy(
             name=self.vault_policy,
-            rules=TEST_POLICY.format(backend=self.vault_backend)
+            policy=TEST_POLICY.format(backend=self.vault_backend),
         )
 
-        self.vault_client.create_role(
-            self.vault_approle,
+        self.vault_client.auth.approle.create_or_update_approle(
+            role_name=self.vault_approle,
             token_ttl='60s',
             token_max_ttl='60s',
-            policies=[self.vault_policy],
-            bind_secret_id='true',
-            bound_cidr_list='127.0.0.1/32')
-        self.approle_uuid = self.vault_client.get_role_id(self.vault_approle)
-        self.secret_id = self.vault_client.write(
-            'auth/approle/role/{}/secret-id'.format(self.vault_approle)
+            token_policies=[self.vault_policy],
+            bind_secret_id=True,
+        )
+        self.approle_uuid = self.vault_client.auth.approle.read_role_id(
+            role_name=self.vault_approle,
+        )['data']['role_id']
+        self.secret_id = self.vault_client.auth.approle.generate_secret_id(
+            role_name=self.vault_approle,
         )['data']['secret_id']
 
         self.test_config = {
@@ -91,10 +93,14 @@ class VaultlockerFuncBaseTestCase(base.BaseTestCase):
         }
         self.config = mock.MagicMock()
         self.config.get.side_effect = \
-            lambda s, k, **kwargs: self.test_config.get(s).get(k)
+            lambda s, k, **kwargs: self.test_config.get(s, {}).get(
+                k, kwargs.get('fallback')
+            )
 
     def tearDown(self):
         super(VaultlockerFuncBaseTestCase, self).tearDown()
         if self.vault_client:
-            self.vault_client.disable_secret_backend(self.vault_backend)
-            self.vault_client.delete_policy(self.vault_policy)
+            self.vault_client.sys.disable_secrets_engine(
+                path=self.vault_backend,
+            )
+            self.vault_client.sys.delete_policy(name=self.vault_policy)

--- a/vaultlocker/tests/unit/test_vaultlocker.py
+++ b/vaultlocker/tests/unit/test_vaultlocker.py
@@ -45,6 +45,19 @@ class TestVaultlocker(base.TestCase):
             return self._test_config.get(k)
         self.config.get.side_effect = side_effect
 
+    @mock.patch.object(shell.hvac, 'Client')
+    def test_vault_client_uses_approle_login(self, _client):
+        client = _client.return_value
+
+        result = shell._vault_client(self.config)
+
+        client.auth.approle.login.assert_called_once_with(
+            role_id=self._test_config['approle'],
+            secret_id=self._test_config['secret_id'],
+        )
+        client.auth_approle.assert_not_called()
+        self.assertIs(result, client)
+
     @mock.patch.object(shell, 'systemd')
     @mock.patch.object(shell, 'dmcrypt')
     @mock.patch.object(shell, '_get_vault_path')


### PR DESCRIPTION
Updates vaultlocker to support python 3.12+ and current hvac releases.
Context: HVAC is the official python client library for HashiCorp Vault, used to authenticate Vault and interact with its API.

## Changes

### hvac

* Replace `Client.auth_approle()` with `Client.auth.approle.login()`.
The old `auth_approle()` method is not available in hvac 1.x or 2.x. hvac 0.10.6 introduced the namespaced AppRole API used here.
  
  * [HVAC 0.10.6 changelog](https://python-hvac.org/en/stable/changelog.html#december-14th-2020)
  * [HVAC AppRole docs](https://python-hvac.org/en/stable/usage/auth_methods/approle.html)

  The other hvac calls currently used by vaultlocker still work with hvac 2.x. KV API changes will be handled separately as part of the KV v2 work.
 
* Set `hvac>=0.10.6` as the minimum supported version.
* Add a regression test for the AppRole login call.
*  Remove the undeclared `six` dependency. A clean installation was failing with with `ModuleNotFoundError: No module named 'six'`


### Tests

* Remove old python 2 and 3 test environments.
* Add noble, resolute, and latest dependency test environments.
* Test each dependency profile against Vault 1.8, 1.18, and 2.0.
* Update the GitHub Actions versions.
* Update the functional tests to use the namespaced hvac `sys` and `auth.approle` APIs and remove deprecated functions [hvac.v1](https://python-hvac.org/en/v0.10.9/source/hvac_v1.html#module-hvac.v1)
* Configure the Vault address and root token in CI so the functional tests run against the Vault service container instead of being skipped.
* Remove the localhost-only AppRole CIDR restriction from the functional test
  * The GitHub Actions runner is reaching the vault service through docker networking rather than directly via 127.0.0.1, so restricting secret IDs to 127.0.0.1/32 cause authentication failures in the CI



### Manual Testing

Manually verified the vaultlocker `encrypt` and `decrypt` flows against a vault instance.

OPEN-4605