### PR TITLE
Adds Vault KV v2 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,12 +14,21 @@ vaultlocker provides a way to store and retrieve dm-crypt encryption
 keys in Vault, automatically retrieving keys and opening LUKS dm-crypt
 devices on boot.
 
-vaultlocker is configured using `/etc/vaultlocker/vaultlocker.conf`::
+vaultlocker is configured using `/etc/vaultlocker/vaultlocker.conf`.
+
+If ``kv_version`` is omitted, vaultlocker uses Vault's KV version 1
+secrets engine. To use a KV version 2 mount, set ``kv_version = 2`` in
+the ``[vault]`` section::
+
+    [DEFAULT]
+    hostname = host-1
 
     [vault]
     url = https://vault.internal:8200
     approle = 4a1b84d2-7bb2-4c07-9804-04d1683ac925
+    secret_id = 9428ad25-7b4a-442f-8f20-f23be0575146
     backend = secret
+    kv_version = 2
 
 vaultlocker defaults to using a backend with the name `secret`.
 

--- a/etc/vaultlocker.conf
+++ b/etc/vaultlocker.conf
@@ -1,6 +1,10 @@
+[DEFAULT]
+#hostname =
+
 [vault]
 url = http://10.5.0.13:8200
 approle = e256bf3b-fb28-b1d6-f2fb-3adc8339d3ad
 secret_id = 9428ad25-7b4a-442f-8f20-f23be0575146
 backend = secret
+#kv_version = 1    # optional, defaults to 1. If you are using KV v2, set this to 2.
 #ca_bundle =

--- a/vaultlocker/shell.py
+++ b/vaultlocker/shell.py
@@ -13,22 +13,24 @@
 # under the License.
 
 import argparse
-import hvac
+import configparser
 import logging
 import os
+import platform
 import socket
-import tenacity
+import subprocess
 import uuid
 
-import configparser
-import subprocess
+import hvac
+import tenacity
+
 from vaultlocker import dmcrypt
 from vaultlocker import exceptions
 from vaultlocker import systemd
+from vaultlocker import vault
 
 logger = logging.getLogger(__name__)
 
-RUN_VAULTLOCKER = '/run/vaultlocker'
 DEFAULT_CONF_FILE = '/etc/vaultlocker/vaultlocker.conf'
 
 
@@ -49,16 +51,94 @@ def _vault_client(config):
     return client
 
 
-def _get_vault_path(device_uuid, config):
-    """Generate full vault path for a given block device UUID
+def _get_kv_version(config):
+    """Return the configured Vault KV version.
 
-    :param: device_uuid: String of the device UUID
-    :param: config: configparser object of vaultlocker config
-    :returns: str: Path to vault resource for device
+    :param config: configparser object of vaultlocker config
+    :returns: str: KV version ('1' or '2')
+    :raises ValueError: If the configured value is not '1' or '2'.
     """
-    return '{}/{}/{}'.format(config.get('vault', 'backend'),
-                             socket.gethostname(),
-                             device_uuid)
+    version = config.get('vault', 'kv_version', fallback=vault.KV_VERSION_1)
+    if version not in (vault.KV_VERSION_1, vault.KV_VERSION_2):
+        raise ValueError(
+            "Invalid kv_version '{}' in vaultlocker config; "
+            "must be '{}' or '{}'".format(
+                version, vault.KV_VERSION_1, vault.KV_VERSION_2
+            )
+        )
+    return version
+
+
+def get_hostname(config):
+    """Determine the hostname to use in Vault paths.
+
+    :param config: configparser object of vaultlocker config
+    :returns: str: hostname to use
+    :raises RuntimeError: if no hostname could be determined
+    """
+    configured = config.get('DEFAULT', 'hostname', fallback=None)
+    if configured:
+        return configured
+
+    node = platform.node()
+    if node:
+        return node
+
+    try:
+        return socket.gethostname()
+    except OSError as hostname_error:
+        raise RuntimeError(
+            'Unable to determine hostname: {}'.format(hostname_error)
+        )
+
+
+def _vault_mount_point(config):
+    """Return the configured Vault secrets-engine mount.
+
+    :param config: configparser object of vaultlocker config
+    :returns: Vault secrets-engine mount point
+    """
+    return config.get('vault', 'backend')
+
+
+def _vault_secret_path(device_uuid, config):
+    """Return the secret path relative to the Vault mount.
+
+    :param device_uuid: String of the device UUID
+    :param config: configparser object of vaultlocker config
+    :returns: Path ``<hostname>/<uuid>`` form
+    """
+    return '{}/{}'.format(
+        get_hostname(config),
+        device_uuid,
+    )
+
+
+def _get_vault_path(device_uuid, config):
+    """Return the complete Vault path.
+
+    :param device_uuid: String of the device UUID
+    :param config: configparser object of vaultlocker config
+    :returns: Path in ``<mount>/<hostname>/<uuid>`` form.
+    """
+    return '{}/{}'.format(
+        _vault_mount_point(config),
+        _vault_secret_path(device_uuid, config),
+    )
+
+
+def _vault_store(client, config):
+    """Create store for the configured Vault KV mount.
+
+    :param client: Authenticated Vault client.
+    :param config: Parsed vaultlocker configuration.
+    :returns: Storage configured with the mount and KV version.
+    """
+    return vault.KVStore.get_store(
+        client=client,
+        mount_point=_vault_mount_point(config),
+        kv_version=_get_kv_version(config),
+    )
 
 
 def _encrypt_block_device(args, client, config):
@@ -73,26 +153,45 @@ def _encrypt_block_device(args, client, config):
     block_device = args.block_device[0]
     key = dmcrypt.generate_key()
     block_uuid = str(uuid.uuid4()) if not args.uuid else args.uuid
-    vault_path = _get_vault_path(block_uuid, config)
+
+    path = _vault_secret_path(block_uuid, config)
+    vault_path = '{}/{}'.format(
+        _vault_mount_point(config),
+        path,
+    )
+    store = _vault_store(client, config)
 
     # NOTE: store and validate key before trying to encrypt disk
     try:
-        client.write(vault_path,
-                     dmcrypt_key=key)
+        store.write(
+            path,
+            {'dmcrypt_key': key},
+        )
     except hvac.exceptions.VaultError as write_error:
         logger.error(
-            'Vault write to path {}. Failed with error: {}'.format(
-                vault_path, write_error))
-        raise exceptions.VaultWriteError(vault_path, write_error)
+            'Vault write to path %s failed with error: %s',
+            vault_path,
+            write_error,
+        )
+        raise exceptions.VaultWriteError(
+            vault_path,
+            write_error,
+        )
 
     try:
-        stored_data = client.read(vault_path)
+        stored_data = store.read(path)
     except hvac.exceptions.VaultError as read_error:
-        logger.error('Vault access to path {}'
-                     'failed with error: {}'.format(vault_path, read_error))
-        raise exceptions.VaultReadError(vault_path, read_error)
+        logger.error(
+            'Vault access to path %s failed with error: %s',
+            vault_path,
+            read_error,
+        )
+        raise exceptions.VaultReadError(
+            vault_path,
+            read_error,
+        )
 
-    if not key == stored_data['data']['dmcrypt_key']:
+    if not key == stored_data['dmcrypt_key']:
         raise exceptions.VaultKeyMismatch(vault_path)
 
     # All function calls within try/catch raise a CalledProcessError
@@ -107,14 +206,15 @@ def _encrypt_block_device(args, client, config):
         dmcrypt.luks_open(key, block_uuid)
     except subprocess.CalledProcessError as luks_error:
         logger.error(
-            'LUKS formatting {} failed with error code: {}\n'
-            'LUKS output: {}'.format(
-                block_device,
-                luks_error.returncode,
-                luks_error.output))
+            'LUKS formatting %s failed with error code: %s\n'
+            'LUKS output: %s',
+            block_device,
+            luks_error.returncode,
+            luks_error.output,
+        )
 
         try:
-            client.delete(vault_path)
+            store.delete(path)
         except hvac.exceptions.VaultError as del_error:
             raise exceptions.VaultDeleteError(vault_path, del_error)
 
@@ -126,7 +226,7 @@ def _encrypt_block_device(args, client, config):
 def _decrypt_block_device(args, client, config):
     """Open a LUKS/dm-crypt encrypted block device
 
-    The devices dm-crypt key is retrieved from Vault
+    The device's dm-crypt key is retrieved from Vault
 
     :param: args: argparser generated cli arguments
     :param: client: hvac.Client for Vault access
@@ -135,16 +235,23 @@ def _decrypt_block_device(args, client, config):
     block_uuid = args.uuid[0]
 
     if _device_exists(block_uuid):
-        logger.info('Skipping setup of {} because '
-                    'it already exists.'.format(block_uuid))
+        logger.info(
+            'Skipping setup of %s because it already exists.',
+            block_uuid,
+        )
         return
 
-    vault_path = _get_vault_path(block_uuid, config)
+    path = _vault_secret_path(block_uuid, config)
+    store = _vault_store(client, config)
 
-    stored_data = client.read(vault_path)
-    if stored_data is None:
-        raise ValueError('Unable to locate key for {}'.format(block_uuid))
-    key = stored_data['data']['dmcrypt_key']
+    try:
+        stored_data = store.read(path)
+    except hvac.exceptions.InvalidPath:
+        raise ValueError(
+            'Unable to locate key for {}'.format(block_uuid)
+        )
+
+    key = stored_data['dmcrypt_key']
 
     dmcrypt.luks_open(key, block_uuid)
 
@@ -153,7 +260,7 @@ def _device_exists(block_uuid):
     """Checks if the device already exists."""
     handle = 'crypt-{}'.format(block_uuid)
     path = "/dev/mapper/{}".format(handle)
-    logger.info('Checking if {} exists.'.format(path))
+    logger.info('Checking if %s exists.', path)
     return os.path.exists(path)
 
 

--- a/vaultlocker/tests/unit/test_vault.py
+++ b/vaultlocker/tests/unit/test_vault.py
@@ -1,0 +1,183 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""
+test_vault
+----------------------------------
+
+Tests for `vaultlocker.vault` module.
+"""
+
+from unittest import mock
+
+import hvac
+
+from vaultlocker.tests.unit import base
+from vaultlocker import vault
+
+
+class TestKVStoreV1(base.TestCase):
+
+    def setUp(self):
+        super(TestKVStoreV1, self).setUp()
+        self.client = mock.MagicMock()
+        self.store = vault.KVStoreV1(self.client, 'vaultlocker-v1')
+
+    def test_write(self):
+        self.store.write('host/device', {'dmcrypt_key': 'test-key'})
+
+        (
+            self.client.secrets.kv.v1
+            .create_or_update_secret
+            .assert_called_once_with(
+                path='host/device',
+                secret={'dmcrypt_key': 'test-key'},
+                mount_point='vaultlocker-v1',
+            )
+        )
+
+    def test_read_unwraps_data(self):
+        self.client.secrets.kv.v1.read_secret.return_value = {
+            'data': {
+                'dmcrypt_key': 'test-key',
+            },
+        }
+
+        self.assertEqual(
+            {'dmcrypt_key': 'test-key'},
+            self.store.read('host/device'),
+        )
+
+    def test_delete(self):
+        self.store.delete('host/device')
+
+        (
+            self.client.secrets.kv.v1.delete_secret
+            .assert_called_once_with(
+                path='host/device',
+                mount_point='vaultlocker-v1',
+            )
+        )
+
+    def test_read_raises(self):
+        self.client.secrets.kv.v1.read_secret.side_effect = (
+            hvac.exceptions.InvalidPath('missing')
+        )
+
+        self.assertRaises(
+            hvac.exceptions.InvalidPath,
+            self.store.read,
+            'host/device',
+        )
+
+
+class TestKVStoreV2(base.TestCase):
+
+    def setUp(self):
+        super(TestKVStoreV2, self).setUp()
+        self.client = mock.MagicMock()
+        self.store = vault.KVStoreV2(self.client, 'vaultlocker-v2')
+
+    def test_write(self):
+        self.store.write(
+            'host/device',
+            {'dmcrypt_key': 'test-key'},
+        )
+
+        (
+            self.client.secrets.kv.v2
+            .create_or_update_secret
+            .assert_called_once_with(
+                path='host/device',
+                secret={'dmcrypt_key': 'test-key'},
+                mount_point='vaultlocker-v2',
+            )
+        )
+
+    def test_read_unwraps_nested_data(self):
+        self.client.secrets.kv.v2.read_secret_version.return_value = {
+            'data': {
+                'data': {
+                    'dmcrypt_key': 'test-key',
+                },
+                'metadata': {
+                    'version': 1,
+                },
+            },
+        }
+
+        self.assertEqual(
+            {'dmcrypt_key': 'test-key'},
+            self.store.read('host/device'),
+        )
+
+    def test_delete(self):
+        self.store.delete('host/device')
+
+        (
+            self.client.secrets.kv.v2
+            .delete_metadata_and_all_versions
+            .assert_called_once_with(
+                path='host/device',
+                mount_point='vaultlocker-v2',
+            )
+        )
+
+    def test_read_raises(self):
+        self.client.secrets.kv.v2.read_secret_version.side_effect = (
+            hvac.exceptions.InvalidPath('missing')
+        )
+
+        self.assertRaises(
+            hvac.exceptions.InvalidPath,
+            self.store.read,
+            'host/device',
+        )
+
+
+class TestKVStoreFactory(base.TestCase):
+
+    def test_get_store_v1(self):
+        client = mock.MagicMock()
+
+        store = vault.KVStore.get_store(
+            client=client,
+            mount_point='vaultlocker-v1',
+            kv_version=vault.KV_VERSION_1,
+        )
+
+        self.assertIsInstance(store, vault.KVStoreV1)
+        self.assertIs(store.client, client)
+        self.assertEqual(store.mount_point, 'vaultlocker-v1')
+
+    def test_get_store_v2(self):
+        client = mock.MagicMock()
+
+        store = vault.KVStore.get_store(
+            client=client,
+            mount_point='vaultlocker-v2',
+            kv_version=vault.KV_VERSION_2,
+        )
+
+        self.assertIsInstance(store, vault.KVStoreV2)
+        self.assertIs(store.client, client)
+        self.assertEqual(store.mount_point, 'vaultlocker-v2')
+
+    def test_get_store_rejects_unsupported_version(self):
+        with self.assertRaises(ValueError) as error:
+            vault.KVStore.get_store(
+                client=mock.MagicMock(),
+                mount_point='vaultlocker-test',
+                kv_version='3',
+            )
+
+        self.assertIn("Unsupported kv_version '3'", str(error.exception))

--- a/vaultlocker/tests/unit/test_vaultlocker.py
+++ b/vaultlocker/tests/unit/test_vaultlocker.py
@@ -19,9 +19,12 @@ test_vaultlocker
 Tests for `vaultlocker` module.
 """
 
+import configparser
 import subprocess
 
 from unittest import mock
+
+import hvac
 
 from vaultlocker import exceptions
 from vaultlocker import shell
@@ -41,9 +44,21 @@ class TestVaultlocker(base.TestCase):
         super(TestVaultlocker, self).__init__(*args, **kwds)
         self.config = mock.MagicMock()
 
-        def side_effect(_, k, **kwargs):
-            return self._test_config.get(k)
+        def side_effect(_, key, **kwargs):
+            return self._test_config.get(
+                key,
+                kwargs.get('fallback'),
+            )
         self.config.get.side_effect = side_effect
+
+    def _hostname_config(self, hostname=None):
+        config = configparser.ConfigParser()
+        config.add_section('vault')
+
+        if hostname is not None:
+            config.set('DEFAULT', 'hostname', hostname)
+
+        return config
 
     @mock.patch.object(shell.hvac, 'Client')
     def test_vault_client_uses_approle_login(self, _client):
@@ -58,54 +73,75 @@ class TestVaultlocker(base.TestCase):
         client.auth_approle.assert_not_called()
         self.assertIs(result, client)
 
+    @mock.patch.object(shell.vault, 'KVStore')
+    def test_vault_store_uses_configured_mount_and_version(self, _kv_store):
+        client = mock.MagicMock()
+
+        result = shell._vault_store(client, self.config)
+
+        _kv_store.get_store.assert_called_once_with(
+            client=client,
+            mount_point='vaultlocker-test',
+            kv_version='1',
+        )
+        self.assertIs(result, _kv_store.get_store.return_value)
+
+    @mock.patch.object(shell, 'get_hostname')
+    @mock.patch.object(shell, '_vault_store')
     @mock.patch.object(shell, 'systemd')
     @mock.patch.object(shell, 'dmcrypt')
-    @mock.patch.object(shell, '_get_vault_path')
-    def test_encrypt(self, _get_vault_path, _dmcrypt, _systemd):
-        _get_vault_path.return_value = 'backend/host/uuid'
+    def test_encrypt(self, _dmcrypt, _systemd, _vault_store, _get_hostname):
+        _get_hostname.return_value = 'host'
         _dmcrypt.generate_key.return_value = 'testkey'
+
+        store = _vault_store.return_value
+        store.read.return_value = {
+            'dmcrypt_key': 'testkey',
+        }
 
         args = mock.MagicMock()
         args.uuid = 'passed-UUID'
         args.block_device = ['/dev/sdb']
 
         client = mock.MagicMock()
-        client.read.return_value = {
-            'data': {
-                'dmcrypt_key': 'testkey'
-            }
-        }
 
         shell._encrypt_block_device(args, client, self.config)
 
-        _dmcrypt.luks_format.assert_called_with(
+        store.write.assert_called_once_with(
+            'host/passed-UUID',
+            {'dmcrypt_key': 'testkey'},
+        )
+        store.read.assert_called_once_with('host/passed-UUID')
+
+        _dmcrypt.luks_format.assert_called_once_with(
             'testkey', '/dev/sdb', 'passed-UUID'
         )
-        _dmcrypt.luks_open.assert_called_with(
+        _dmcrypt.luks_open.assert_called_once_with(
             'testkey', 'passed-UUID'
         )
-        _systemd.enable.assert_called_with(
+        _systemd.enable.assert_called_once_with(
             'vaultlocker-decrypt@passed-UUID.service'
         )
 
+    @mock.patch.object(shell, 'get_hostname')
+    @mock.patch.object(shell, '_vault_store')
     @mock.patch.object(shell, 'systemd')
     @mock.patch.object(shell, 'dmcrypt')
-    @mock.patch.object(shell, '_get_vault_path')
-    def test_encrypt_vault_failure(self, _get_vault_path,
-                                   _dmcrypt, _systemd):
-        _get_vault_path.return_value = 'backend/host/uuid'
+    def test_encrypt_key_mismatch(self, _dmcrypt, _systemd,
+                                  _vault_store, _get_hostname):
+        _get_hostname.return_value = 'host'
         _dmcrypt.generate_key.return_value = 'testkey'
+
+        store = _vault_store.return_value
+        store.read.return_value = {
+            'dmcrypt_key': 'brokendata',
+        }
 
         args = mock.MagicMock()
         args.uuid = 'passed-UUID'
         args.block_device = ['/dev/sdb']
 
         client = mock.MagicMock()
-        client.read.return_value = {
-            'data': {
-                'dmcrypt_key': 'brokendata'
-            }
-        }
 
         self.assertRaises(
             exceptions.VaultKeyMismatch,
@@ -113,73 +149,125 @@ class TestVaultlocker(base.TestCase):
             args, client, self.config
         )
 
-    @mock.patch.object(shell, 'os')
+        _dmcrypt.luks_format.assert_not_called()
+        _systemd.enable.assert_not_called()
+
+    @mock.patch.object(shell, '_device_exists', return_value=False)
+    @mock.patch.object(shell, 'get_hostname')
+    @mock.patch.object(shell, '_vault_store')
     @mock.patch.object(shell, 'dmcrypt')
-    @mock.patch.object(shell, '_get_vault_path')
-    def test_decrypt(self, _get_vault_path, _dmcrypt, _os):
-        _get_vault_path.return_value = 'backend/host/uuid'
-        _os.path.exists.return_value = False
+    def test_decrypt(self, _dmcrypt, _vault_store, _get_hostname,
+                     _device_exists):
+        _get_hostname.return_value = 'host'
+
+        store = _vault_store.return_value
+        store.read.return_value = {
+            'dmcrypt_key': 'testkey',
+        }
+
         args = mock.MagicMock()
         args.uuid = ['passed-UUID']
 
         client = mock.MagicMock()
-        client.read.return_value = {
-            'data': {
-                'dmcrypt_key': 'testkey'
-            }
-        }
 
         shell._decrypt_block_device(args, client, self.config)
 
-        _dmcrypt.luks_open.assert_called_with(
+        store.read.assert_called_once_with('host/passed-UUID')
+        _dmcrypt.luks_open.assert_called_once_with(
             'testkey', 'passed-UUID'
         )
 
-    @mock.patch.object(shell, 'os')
-    @mock.patch.object(shell, '_get_vault_path')
-    def test_decrypt_already_exists(self, _get_vault_path, _os):
-        _os.path.exists.return_value = True
+    @mock.patch.object(shell, '_device_exists', return_value=False)
+    @mock.patch.object(shell, 'get_hostname')
+    @mock.patch.object(shell, '_vault_store')
+    @mock.patch.object(shell, 'dmcrypt')
+    def test_decrypt_missing_key(self, _dmcrypt, _vault_store, _get_hostname,
+                                 _device_exists):
+        _get_hostname.return_value = 'host'
+
+        store = _vault_store.return_value
+        store.read.side_effect = hvac.exceptions.InvalidPath('missing')
 
         args = mock.MagicMock()
         args.uuid = ['passed-UUID']
+
         client = mock.MagicMock()
-        client.read.return_value = {
-            'data': {
-                'dmcrypt_key': 'testkey'
-            }
-        }
+
+        with self.assertRaises(ValueError) as error:
+            shell._decrypt_block_device(args, client, self.config)
+
+        self.assertEqual(
+            'Unable to locate key for passed-UUID',
+            str(error.exception),
+        )
+        _dmcrypt.luks_open.assert_not_called()
+
+    @mock.patch.object(shell, '_device_exists', return_value=False)
+    @mock.patch.object(shell, 'get_hostname')
+    @mock.patch.object(shell, '_vault_store')
+    def test_decrypt_vault_error(self, _vault_store, _get_hostname,
+                                 _device_exists):
+        _get_hostname.return_value = 'host'
+
+        store = _vault_store.return_value
+        store.read.side_effect = hvac.exceptions.Forbidden('denied')
+
+        args = mock.MagicMock()
+        args.uuid = ['passed-UUID']
+
+        client = mock.MagicMock()
+
+        self.assertRaises(
+            hvac.exceptions.Forbidden,
+            shell._decrypt_block_device,
+            args, client, self.config
+        )
+
+    @mock.patch.object(shell, '_vault_store')
+    @mock.patch.object(shell, '_device_exists', return_value=True)
+    def test_decrypt_already_exists(self, _device_exists, _vault_store):
+        args = mock.MagicMock()
+        args.uuid = ['passed-UUID']
+
+        client = mock.MagicMock()
 
         self.assertIsNone(
-            shell._decrypt_block_device(args, client, self.config))
+            shell._decrypt_block_device(args, client, self.config)
+        )
 
-        _get_vault_path.assert_not_called()
+        _vault_store.assert_not_called()
 
-    @mock.patch.object(shell, 'socket')
-    def test_get_vault_path(self, _socket):
-        _socket.gethostname.return_value = 'myhost'
-        self.assertEqual(shell._get_vault_path('my-UUID', self.config),
-                         'vaultlocker-test/myhost/my-UUID')
+    @mock.patch.object(shell, 'get_hostname')
+    def test_get_vault_path(self, _get_hostname):
+        _get_hostname.return_value = 'myhost'
 
+        self.assertEqual(
+            shell._get_vault_path('my-UUID', self.config),
+            'vaultlocker-test/myhost/my-UUID'
+        )
+
+    @mock.patch.object(shell, 'get_hostname')
+    @mock.patch.object(shell, '_vault_store')
     @mock.patch.object(shell, 'systemd')
     @mock.patch.object(shell, 'dmcrypt')
-    @mock.patch.object(shell, '_get_vault_path')
-    def test_encrypt_luks_failure(self, _get_vault_path, _dmcrypt, _systemd):
-        _get_vault_path.return_value = 'backend/host/uuid'
+    def test_encrypt_luks_failure(self, _dmcrypt, _systemd,
+                                  _vault_store, _get_hostname):
+        _get_hostname.return_value = 'host'
         _dmcrypt.generate_key.return_value = 'testkey'
         _dmcrypt.luks_format.side_effect = \
             subprocess.CalledProcessError(returncode=-1,
-                                          cmd="echo Unit Test")
+                                          cmd='echo Unit Test')
+
+        store = _vault_store.return_value
+        store.read.return_value = {
+            'dmcrypt_key': 'testkey',
+        }
 
         args = mock.MagicMock()
         args.uuid = 'passed-UUID'
         args.block_device = ['/dev/sdb']
 
         client = mock.MagicMock()
-        client.read.return_value = {
-            'data': {
-                'dmcrypt_key': 'testkey'
-            }
-        }
 
         self.assertRaises(
             exceptions.LUKSFailure,
@@ -187,74 +275,152 @@ class TestVaultlocker(base.TestCase):
             args, client, self.config
         )
 
-        client.delete.assert_called_once_with('backend/host/uuid')
+        store.delete.assert_called_once_with('host/passed-UUID')
+        _systemd.enable.assert_not_called()
 
-    @mock.patch.object(shell, 'systemd')
+    @mock.patch.object(shell, 'get_hostname')
+    @mock.patch.object(shell, '_vault_store')
     @mock.patch.object(shell, 'dmcrypt')
-    @mock.patch.object(shell, '_get_vault_path')
-    def test_vault_write_operation(self, _get_vault_path,
-                                   _dmcrypt, _systemd):
-        _get_vault_path.return_value = 'backend/host/uuid'
+    def test_vault_write_operation(self, _dmcrypt, _vault_store,
+                                   _get_hostname):
+        _get_hostname.return_value = 'host'
         _dmcrypt.generate_key.return_value = 'testkey'
+
+        store = _vault_store.return_value
+        store.write.side_effect = hvac.exceptions.Forbidden('denied')
 
         args = mock.MagicMock()
         args.uuid = 'passed-UUID'
         args.block_device = ['/dev/sdb']
 
         client = mock.MagicMock()
-        client.read.return_value = {
-            'data': {
-                'dmcrypt_key': 'testkey'
-            }
-        }
 
-        self.assertIsNot(
-            exceptions.VaultWriteError,
-            shell._encrypt_block_device(
-                args,
-                client,
-                self.config))
-
-        client.write.side_effect = exceptions.VaultWriteError(
-            'backend/host/uuid', 'Write Failed')
         self.assertRaises(
             exceptions.VaultWriteError,
             shell._encrypt_block_device,
-            args,
-            client,
-            self.config)
+            args, client, self.config
+        )
 
-    @mock.patch.object(shell, 'systemd')
+    @mock.patch.object(shell, 'get_hostname')
+    @mock.patch.object(shell, '_vault_store')
     @mock.patch.object(shell, 'dmcrypt')
-    @mock.patch.object(shell, '_get_vault_path')
-    def test_vault_read_operation(self, _get_vault_path,
-                                  _dmcrypt, _systemd):
-        _get_vault_path.return_value = 'backend/host/uuid'
+    def test_vault_read_operation(self, _dmcrypt, _vault_store,
+                                  _get_hostname):
+        _get_hostname.return_value = 'host'
         _dmcrypt.generate_key.return_value = 'testkey'
+
+        store = _vault_store.return_value
+        store.read.side_effect = hvac.exceptions.Forbidden('denied')
 
         args = mock.MagicMock()
         args.uuid = 'passed-UUID'
         args.block_device = ['/dev/sdb']
 
         client = mock.MagicMock()
-        client.read.return_value = {
-            'data': {
-                'dmcrypt_key': 'testkey'
-            }
-        }
 
-        self.assertIsNot(
-            exceptions.VaultReadError,
-            shell._encrypt_block_device(
-                args,
-                client,
-                self.config))
-
-        client.read.side_effect = exceptions.VaultReadError(
-            'backend/host/uuid', 'Write Failed')
         self.assertRaises(
             exceptions.VaultReadError,
             shell._encrypt_block_device,
-            args,
-            client,
-            self.config)
+            args, client, self.config
+        )
+
+    @mock.patch.object(shell, 'socket')
+    @mock.patch.object(shell, 'platform')
+    def test_get_hostname_uses_configured_value(self, _platform, _socket):
+        self.assertEqual(
+            'configured-host',
+            shell.get_hostname(
+                self._hostname_config('configured-host')
+            ),
+        )
+
+        _platform.node.assert_not_called()
+        _socket.gethostname.assert_not_called()
+
+    @mock.patch.object(shell, 'socket')
+    @mock.patch.object(shell, 'platform')
+    def test_get_hostname_uses_platform_node(self, _platform, _socket):
+        _platform.node.return_value = 'node-host'
+
+        self.assertEqual(
+            'node-host',
+            shell.get_hostname(self._hostname_config()),
+        )
+
+        _socket.gethostname.assert_not_called()
+
+    @mock.patch.object(shell, 'socket')
+    @mock.patch.object(shell, 'platform')
+    def test_get_hostname_uses_socket_fallback(self, _platform, _socket):
+        _platform.node.return_value = ''
+        _socket.gethostname.return_value = 'socket-host'
+
+        self.assertEqual(
+            'socket-host',
+            shell.get_hostname(self._hostname_config()),
+        )
+
+        _socket.gethostname.assert_called_once_with()
+
+    @mock.patch.object(shell, 'socket')
+    @mock.patch.object(shell, 'platform')
+    def test_get_hostname_raises_when_socket_fails(self, _platform, _socket):
+        _platform.node.return_value = ''
+        _socket.gethostname.side_effect = OSError('no hostname')
+
+        with self.assertRaises(RuntimeError) as error:
+            shell.get_hostname(self._hostname_config())
+
+        self.assertIn(
+            'Unable to determine hostname',
+            str(error.exception),
+        )
+
+
+class TestKVConfiguration(base.TestCase):
+
+    def _config(self, kv_version=None):
+        config = configparser.ConfigParser()
+        config.add_section('vault')
+        config.set('vault', 'backend', 'vaultlocker-test')
+
+        if kv_version is not None:
+            config.set('vault', 'kv_version', kv_version)
+
+        return config
+
+    def test_kv_version_defaults_to_one(self):
+        self.assertEqual(
+            '1',
+            shell._get_kv_version(self._config()),
+        )
+
+    def test_kv_version_one(self):
+        self.assertEqual(
+            '1',
+            shell._get_kv_version(self._config('1')),
+        )
+
+    def test_kv_version_two(self):
+        self.assertEqual(
+            '2',
+            shell._get_kv_version(self._config('2')),
+        )
+
+    def test_kv_version_rejects_other_number(self):
+        with self.assertRaises(ValueError) as error:
+            shell._get_kv_version(self._config('3'))
+
+        self.assertIn(
+            "must be '1' or '2'",
+            str(error.exception),
+        )
+
+    @mock.patch.object(shell, 'get_hostname')
+    def test_secret_path_is_relative_to_mount(self, _get_hostname):
+        _get_hostname.return_value = 'test-host'
+
+        self.assertEqual(
+            'test-host/test-uuid',
+            shell._vault_secret_path('test-uuid', self._config()),
+        )

--- a/vaultlocker/vault.py
+++ b/vaultlocker/vault.py
@@ -1,0 +1,126 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import abc
+from typing import Any
+
+import hvac
+
+KV_VERSION_1 = '1'
+KV_VERSION_2 = '2'
+
+
+class KVStoreBase(abc.ABC):
+    """Base class for accessing a Vault KV secrets engine."""
+
+    def __init__(self, client: hvac.Client, mount_point: str) -> None:
+        self.client = client
+        self.mount_point = mount_point
+
+    @abc.abstractmethod
+    def write(self, path: str, secret: dict[str, Any]) -> None:
+        """Write a secret.
+
+        :param path: path to the secret relative to the mount point
+        :param secret: dictionary containing the secret data
+        """
+
+    @abc.abstractmethod
+    def read(self, path: str) -> dict[str, Any]:
+        """Return an unwrapped secret dictionary.
+
+        :param path: path to the secret relative to the mount point
+        :return: dictionary containing the secret data
+        """
+
+    @abc.abstractmethod
+    def delete(self, path: str) -> None:
+        """Permanently delete a secret.
+
+        :param path: path to the secret relative to the mount point
+        """
+
+
+class KVStoreV1(KVStoreBase):
+    """Access a Vault KV version 1 secrets engine."""
+
+    def write(self, path: str, secret: dict[str, Any]) -> None:
+        self.client.secrets.kv.v1.create_or_update_secret(
+            path=path,
+            secret=secret,
+            mount_point=self.mount_point,
+        )
+
+    def read(self, path: str) -> dict[str, Any]:
+        response = self.client.secrets.kv.v1.read_secret(
+            path=path,
+            mount_point=self.mount_point,
+        )
+        return response['data']
+
+    def delete(self, path: str) -> None:
+        self.client.secrets.kv.v1.delete_secret(
+            path=path,
+            mount_point=self.mount_point,
+        )
+
+
+class KVStoreV2(KVStoreBase):
+    """Access a Vault KV version 2 secrets engine."""
+
+    def write(self, path: str, secret: dict[str, Any]) -> None:
+        self.client.secrets.kv.v2.create_or_update_secret(
+            path=path,
+            secret=secret,
+            mount_point=self.mount_point,
+        )
+
+    def read(self, path: str) -> dict[str, Any]:
+        response = self.client.secrets.kv.v2.read_secret_version(
+            path=path,
+            mount_point=self.mount_point,
+        )
+        return response['data']['data']
+
+    def delete(self, path: str) -> None:
+        self.client.secrets.kv.v2.delete_metadata_and_all_versions(
+            path=path,
+            mount_point=self.mount_point,
+        )
+
+
+class KVStore:
+    """Factory for KV store implementations."""
+
+    _registry = {
+        KV_VERSION_1: KVStoreV1,
+        KV_VERSION_2: KVStoreV2,
+    }
+
+    @classmethod
+    def get_store(
+        cls, client: hvac.Client, mount_point: str, kv_version: str
+    ) -> KVStoreBase:
+        """Return a KV store implementation for the given version.
+
+        :param client: Authenticated hvac.Client.
+        :param mount_point: Vault secrets-engine mount point.
+        :param kv_version: KV secrets engine version.
+        :returns: KVStoreBase: configured store implementation.
+        :raises ValueError: if kv_version is not a supported value.
+        """
+        store_class = cls._registry.get(kv_version)
+        if store_class is None:
+            raise ValueError(
+                "Unsupported kv_version '{}'".format(kv_version)
+            )
+        return store_class(client, mount_point)


### PR DESCRIPTION
Adds support for Vault KV v2 while keeping KV v1 as the default for existing deployments.

## Changes

### Vault KV support

Add an optional `kv_version` setting to `vaultlocker.conf`.

This is needed because the HVAC APIs and response formats are different for KV v1 and KV v2.

When the setting is omitted, vaultlocker continues to use KV v1, so existing deployments do not need to update their configuration.

Only KV versions `1` and `2` are accepted.

### Secret storage

Add separate `KVStoreV1` and `KVStoreV2` implementations for the HVAC KV APIs.

This:

* Uses the configured KV mount and version.
* Handles the different KV v1 and KV v2 read response formats.
* Provides the same read, write, and delete interface to vaultlocker.
* Permanently removes the secret and its metadata when deleting a KV v2 secret.

Update the encrypt and decrypt flows to use the new storage interface.


### Compatibility

KV v1 remains the default, so existing deployments continue to read and write keys from the same paths.

Operators who want to move an existing mount to KV v2 can use
[Vault's in-place KV upgrade](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v2/upgrade)
and then set:

```ini
kv_version = 2
```

Vaultlocker does not need a separate migration command because this is handled by vault.

## Tests

* Add unit tests for KV v1 and KV v2 reads, writes, and deletes.
* Test the default and configured `kv_version` values.
* Update the encrypt and decrypt tests to use the new storage interface.

## Manual testing

Manually verified the vaultlocker encrypt and decrypt flows using Vault KV v1 and KV v2.

Assisted By: GPT-5.6 Sol

Related-bug: [#2158148](https://bugs.launchpad.net/vaultlocker/+bug/2158148)
**Jira:** OPEN-4605

