### PR TITLE
feat: adds support for managing existing LUKS devices

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,9 @@ vaultlocker provides a way to store and retrieve dm-crypt encryption
 keys in Vault, automatically retrieving keys and opening LUKS dm-crypt
 devices on boot.
 
+Configuration
+-------------
+
 vaultlocker is configured using `/etc/vaultlocker/vaultlocker.conf`.
 
 If ``kv_version`` is omitted, vaultlocker uses Vault's KV version 1
@@ -32,6 +35,9 @@ the ``[vault]`` section::
 
 vaultlocker defaults to using a backend with the name `secret`.
 
+Encrypting a block device
+-------------------------
+
 A block device can be encrypted and its key stored in vault::
 
     sudo vaultlocker encrypt /dev/sdd1
@@ -44,11 +50,40 @@ Unless a UUID is provided (using the optional --uuid flag)
 vaultlocker will generate a UUID to label and identify the block
 device during subsequent operations.
 
+Enrolling an existing LUKS device
+---------------------------------
+
+An existing LUKS block device can be enrolled and a vaultlocker-managed
+key stored in vault::
+
+    sudo vaultlocker enroll /dev/sdd1
+
+vaultlocker will prompt for the existing LUKS passphrase when run
+interactively. When standard input is redirected, the existing key
+will be read from standard input.
+
+The existing key can also be read from a file using the optional
+--existing-key-file flag::
+
+    sudo vaultlocker enroll --existing-key-file /path/to/key /dev/sdd1
+
+This will add the vaultlocker-managed key without removing the existing
+key. vaultlocker will not store the existing key in vault.
+
+The block device will be opened and a systemd unit enabled to
+automatically retrieve the managed key and open the device on boot.
+
+Opening a block device
+----------------------
+
 A block device can also be opened from the command line using its
 UUID (hint - the block device or partition will be labelled with the
 UUID)::
 
     sudo vaultlocker decrypt f65b9e66-8f0c-4cae-b6f5-6ec85ea134f2
+
+Vault authentication
+--------------------
 
 Authentication to Vault is done using an AppRole with a secret_id; its assumed
 that a CIDR based ACL is in use to only allow permitted systems within the

--- a/vaultlocker/dmcrypt.py
+++ b/vaultlocker/dmcrypt.py
@@ -23,6 +23,17 @@ logger = logging.getLogger(__name__)
 KEY_SIZE = 4096
 
 
+def _key_bytes(key):
+    """Normalize key material for subprocess input.
+
+    Vault-managed keys are stored as strings, operator-provided keys
+    read from stdin or a file are already bytes.
+    """
+    if isinstance(key, bytes):
+        return key
+    return key.encode('utf-8')
+
+
 def generate_key():
     """Generate a 4096 bit random key for use with dm-crypt
 
@@ -54,12 +65,14 @@ def luks_format(key, device, uuid):
         'luksFormat',
         device,
     ]
-    subprocess.check_output(command,
-                            input=key.encode('UTF-8'))
+    subprocess.check_output(
+        command,
+        input=_key_bytes(key),
+    )
 
 
 def luks_open(key, uuid):
-    """LUKS open a block device by UUID
+    """LUKS open a block device by UUID.
 
     Open a block device using dm-crypt/LUKS with the
     provided key and uuid
@@ -68,7 +81,7 @@ def luks_open(key, uuid):
     :param: uuid: uuid to use for encrypted block device.
     :returns: str. dm-crypt mapping
     """
-    logger.info('LUKS opening {}'.format(uuid))
+    logger.info('LUKS opening %s', uuid)
     handle = 'crypt-{}'.format(uuid)
     command = [
         'cryptsetup',
@@ -81,20 +94,107 @@ def luks_open(key, uuid):
         '--type',
         'luks',
     ]
-    subprocess.check_output(command,
-                            input=key.encode('UTF-8'))
+    subprocess.check_output(
+        command,
+        input=_key_bytes(key),
+    )
     return handle
 
 
+def luks_uuid(device):
+    """Get the UUID of a LUKS-formatted block device.
+
+    :param: device: full path to block device to use.
+    :returns: str. UUID of the LUKS-formatted block device.
+    """
+    logger.info('Getting LUKS UUID for %s', device)
+    command = [
+        'cryptsetup',
+        'luksUUID',
+        device,
+    ]
+    return subprocess.check_output(command).decode('utf-8').strip()
+
+
+def luks_test_key(key, device):
+    """Test a key against a LUKS-formatted block device.
+
+    :param: key: encryption key to test.
+    :param: device: full path to block device to use.
+    :returns: bool. True if the key is valid, otherwise False.
+    """
+    logger.info('Testing LUKS key for %s', device)
+    # `--key-file -` for cryptsetup to read the passphrase from stdin
+    command = [
+        'cryptsetup',
+        '--batch-mode',
+        '--key-file',
+        '-',
+        'open',
+        '--test-passphrase',
+        device,
+    ]
+
+    try:
+        subprocess.check_output(
+            command,
+            input=_key_bytes(key),
+        )
+    except subprocess.CalledProcessError as exc:
+        if exc.returncode == 2:
+            return False
+        raise
+
+    return True
+
+
+def luks_add_key(existing_key, new_key, device):
+    """Add a key to a LUKS-formatted block device.
+
+    :param: existing_key: existing valid encryption key.
+    :param: new_key: new encryption key to add.
+    :param: device: full path to block device to use.
+    """
+    logger.info('Adding a new LUKS key to %s', device)
+
+    existing_key_fd = os.memfd_create(
+        'vaultlocker-existing-key'
+    )
+    try:
+        os.write(
+            existing_key_fd,
+            _key_bytes(existing_key),
+        )
+        os.lseek(existing_key_fd, 0, os.SEEK_SET)
+
+        command = [
+            'cryptsetup',
+            '--batch-mode',
+            '--key-file',
+            '/proc/self/fd/{}'.format(existing_key_fd),  # existing via memfd
+            '--new-keyfile',  # new key via stdin
+            '-',
+            'luksAddKey',
+            device,
+        ]
+        subprocess.check_output(
+            command,
+            input=_key_bytes(new_key),
+            pass_fds=(existing_key_fd,),
+        )
+    finally:
+        os.close(existing_key_fd)
+
+
 def udevadm_rescan(device):
-    """udevadm trigger for block device addition
+    """udevadm trigger for block device addition.
 
     Rescan for block devices to ensure that by-uuid devices are
     created before use.
 
     :param: device: full path to block device to use.
     """
-    logger.info('udevadm trigger block/add for {}'.format(device))
+    logger.info('udevadm trigger block/add for %s', device)
     command = [
         'udevadm',
         'trigger',
@@ -112,7 +212,7 @@ def udevadm_settle(uuid):
 
     :param: uuid: uuid to use for encrypted block device.
     """
-    logger.info('udevadm settle /dev/disk/by-uuid/{}'.format(uuid))
+    logger.info('udevadm settle /dev/disk/by-uuid/%s', uuid)
     command = [
         'udevadm',
         'settle',

--- a/vaultlocker/shell.py
+++ b/vaultlocker/shell.py
@@ -14,11 +14,14 @@
 
 import argparse
 import configparser
+import functools
+import getpass
 import logging
 import os
 import platform
 import socket
 import subprocess
+import sys
 import uuid
 
 import hvac
@@ -141,27 +144,13 @@ def _vault_store(client, config):
     )
 
 
-def _encrypt_block_device(args, client, config):
-    """Encrypt and open a block device
-
-    Stores the dm-crypt key direct in vault
-
-    :param: args: argparser generated cli arguments
-    :param: client: hvac.Client for Vault access
-    :param: config: configparser object of vaultlocker config
-    """
-    block_device = args.block_device[0]
-    key = dmcrypt.generate_key()
-    block_uuid = str(uuid.uuid4()) if not args.uuid else args.uuid
-
-    path = _vault_secret_path(block_uuid, config)
+def _store_and_validate_key(store, path, key):
+    """Store a dm-crypt key in Vault and validate if it was stored."""
     vault_path = '{}/{}'.format(
-        _vault_mount_point(config),
+        store.mount_point,
         path,
     )
-    store = _vault_store(client, config)
 
-    # NOTE: store and validate key before trying to encrypt disk
     try:
         store.write(
             path,
@@ -191,8 +180,146 @@ def _encrypt_block_device(args, client, config):
             read_error,
         )
 
-    if not key == stored_data['dmcrypt_key']:
+    if key != stored_data['dmcrypt_key']:
         raise exceptions.VaultKeyMismatch(vault_path)
+
+
+def _read_existing_key(key_file):
+    """Read an existing LUKS key from a file or standard input.
+
+    Prompt without echo when standard input is an interactive terminal.
+
+    :param: key_file: file path, or None to use standard input.
+    :returns: bytes containing the existing key.
+    """
+    if key_file:
+        with open(key_file, 'rb') as key_source:
+            key = key_source.read()
+    elif sys.stdin.isatty():
+        key = getpass.getpass(
+            'Existing LUKS passphrase: '
+        ).encode('utf-8')
+    else:
+        key = sys.stdin.buffer.read()
+
+    if not key:
+        raise ValueError('Existing LUKS key cannot be empty')
+
+    return key
+
+
+def _get_or_create_managed_key(store, path):
+    """Return an existing managed key or create one and store it in Vault.
+
+    :param: store: Vault key-value store object.
+    :param: path: path to the managed key in Vault.
+    :returns: managed key as str
+    """
+    try:
+        stored_data = store.read(path)
+    except hvac.exceptions.InvalidPath:
+        key = dmcrypt.generate_key()
+        _store_and_validate_key(store, path, key)
+        return key
+
+    if (
+            not isinstance(stored_data, dict) or
+            not stored_data.get('dmcrypt_key')
+    ):
+        raise ValueError(
+            'Vault secret at {}/{} does not contain dmcrypt_key'.format(
+                store.mount_point,
+                path,
+            )
+        )
+
+    return stored_data['dmcrypt_key']
+
+
+def _enroll_block_device(args, client, config, existing_key):
+    """Add a Vault-managed key to an existing LUKS device.
+
+    :param: args: argparser generated CLI arguments.
+    :param: client: hvac.Client for Vault access.
+    :param: config: configparser object of vaultlocker config.
+    :param: existing_key: existing key used to unlock the device.
+    """
+    block_device = args.block_device[0]
+
+    try:
+        block_uuid = dmcrypt.luks_uuid(block_device)
+
+        if not dmcrypt.luks_test_key(existing_key, block_device):
+            raise ValueError(
+                'Existing key does not unlock {}'.format(block_device)
+            )
+    except subprocess.CalledProcessError as luks_error:
+        raise exceptions.LUKSFailure(
+            block_device,
+            luks_error.output,
+        )
+
+    path = _vault_secret_path(block_uuid, config)
+    store = _vault_store(client, config)
+    key = _get_or_create_managed_key(store, path)
+
+    try:
+        if not dmcrypt.luks_test_key(key, block_device):
+            dmcrypt.luks_add_key(
+                existing_key,
+                key,
+                block_device,
+            )
+
+            if not dmcrypt.luks_test_key(key, block_device):
+                raise exceptions.LUKSFailure(
+                    block_device,
+                    'Vaultlocker managed key unable to unlock the device',
+                )
+
+        if not _device_exists(block_uuid):
+            dmcrypt.luks_open(key, block_uuid)
+
+    except subprocess.CalledProcessError as luks_error:
+        logger.error(
+            'LUKS enrollment for %s failed with error code: %s\n'
+            'LUKS output: %s',
+            block_device,
+            luks_error.returncode,
+            luks_error.output,
+        )
+        raise exceptions.LUKSFailure(
+            block_device,
+            luks_error.output,
+        )
+
+    systemd.enable(
+        'vaultlocker-decrypt@{}.service'.format(block_uuid)
+    )
+
+
+def _encrypt_block_device(args, client, config):
+    """Encrypt and open a block device
+
+    Stores the dm-crypt key direct in vault
+
+    :param: args: argparser generated cli arguments
+    :param: client: hvac.Client for Vault access
+    :param: config: configparser object of vaultlocker config
+    """
+    block_device = args.block_device[0]
+    key = dmcrypt.generate_key()
+    block_uuid = str(uuid.uuid4()) if not args.uuid else args.uuid
+
+    path = _vault_secret_path(block_uuid, config)
+    vault_path = '{}/{}'.format(
+        _vault_mount_point(config),
+        path,
+    )
+    store = _vault_store(client, config)
+
+    # NOTE: store and validate key before trying to encrypt disk
+    _store_and_validate_key(store, path, key)
 
     # All function calls within try/catch raise a CalledProcessError
     # if return code is non-zero
@@ -298,6 +425,28 @@ def encrypt(args, config):
     _do_it_with_persistence(_encrypt_block_device, args, config)
 
 
+def enroll(args, config):
+    """Enroll and open handler.
+
+    :param: args: argparser generated CLI arguments.
+    :param: config: configparser object of vaultlocker config.
+    """
+    # Read the existing key once because stdin cannot be reread during retries,
+    # then bind it to the enrollment operation.
+    existing_key = _read_existing_key(args.existing_key_file)
+
+    enroll_operation = functools.partial(
+        _enroll_block_device,
+        existing_key=existing_key,
+    )
+
+    _do_it_with_persistence(
+        enroll_operation,
+        args,
+        config,
+    )
+
+
 def decrypt(args, config):
     """Decrypt and open handler
 
@@ -356,6 +505,25 @@ def main():
                                 help="Full path to block device to encrypt")
     encrypt_parser.set_defaults(func=encrypt)
 
+    enroll_parser = subparsers.add_parser(
+        'enroll',
+        help='Add a Vault-managed key to an existing LUKS device'
+    )
+    enroll_parser.add_argument(
+        '--existing-key-file',
+        help=(
+            "Existing LUKS key file. If omitted, read from stdin or prompt "
+            "when run interactively"
+        )
+    )
+    enroll_parser.add_argument(
+        'block_device',
+        metavar='BLOCK_DEVICE',
+        nargs=1,
+        help='Full path to the existing LUKS device'
+    )
+    enroll_parser.set_defaults(func=enroll)
+
     decrypt_parser = subparsers.add_parser(
         'decrypt',
         help='Decrypt a block device retrieving its key from Vault'
@@ -373,7 +541,7 @@ def main():
         if (len(vars(args)) <= 2):
             parser.print_help()
         else:
-            args.func(args, get_config())
+            args.func(args, get_config(args.config))
     except Exception as e:
         raise SystemExit(
             '{prog}: {msg}'.format(

--- a/vaultlocker/tests/unit/test_dmcrypt.py
+++ b/vaultlocker/tests/unit/test_dmcrypt.py
@@ -20,6 +20,7 @@ Tests for `dmcrypt` module.
 """
 
 import base64
+import subprocess
 from unittest import mock
 
 from vaultlocker import dmcrypt
@@ -40,6 +41,16 @@ class TestDMCrypt(base.TestCase):
             input='mykey'.encode('UTF-8')
         )
 
+    def test_key_bytes_from_string(self):
+        self.assertEqual(
+            dmcrypt._key_bytes("pässphrase"),
+            "pässphrase".encode("utf-8"),
+        )
+
+    def test_key_bytes_from_bytes(self):
+        key = b"passphrase"
+        self.assertEqual(dmcrypt._key_bytes(key), key)
+
     @mock.patch.object(dmcrypt, 'subprocess')
     def test_luks_open(self, _subprocess):
         dmcrypt.luks_open('mykey', 'test-uuid')
@@ -59,6 +70,145 @@ class TestDMCrypt(base.TestCase):
         self.assertEqual(dmcrypt.generate_key(),
                          base64.b64encode(_key).decode('UTF-8'))
         _os.urandom.assert_called_with(dmcrypt.KEY_SIZE / 8)
+
+    @mock.patch.object(dmcrypt, 'subprocess')
+    def test_luks_uuid(self, _subprocess):
+        _subprocess.check_output.return_value = b'test-uuid\n'
+
+        self.assertEqual(
+            dmcrypt.luks_uuid('/dev/sdb'),
+            'test-uuid'
+        )
+        _subprocess.check_output.assert_called_once_with(
+            ['cryptsetup',
+             'luksUUID',
+             '/dev/sdb']
+        )
+
+    @mock.patch.object(dmcrypt.subprocess, 'check_output')
+    def test_luks_uuid_failure(self, _check_output):
+        _check_output.side_effect = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=['cryptsetup']
+        )
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            dmcrypt.luks_uuid('/dev/sdb')
+
+        _check_output.assert_called_once_with(
+            ['cryptsetup',
+             'luksUUID',
+             '/dev/sdb']
+        )
+
+    @mock.patch.object(dmcrypt, 'subprocess')
+    def test_luks_test_key_valid(self, _subprocess):
+        self.assertTrue(
+            dmcrypt.luks_test_key('mykey', '/dev/sdb')
+        )
+        _subprocess.check_output.assert_called_once_with(
+            ['cryptsetup',
+             '--batch-mode',
+             '--key-file', '-',
+             'open',
+             '--test-passphrase',
+             '/dev/sdb'],
+            input=b'mykey'
+        )
+
+    @mock.patch.object(dmcrypt.subprocess, 'check_output')
+    def test_luks_test_key_invalid(self, _check_output):
+        _check_output.side_effect = subprocess.CalledProcessError(
+            returncode=2,
+            cmd=['cryptsetup']
+        )
+
+        self.assertFalse(
+            dmcrypt.luks_test_key('mykey', '/dev/sdb')
+        )
+        _check_output.assert_called_once_with(
+            ['cryptsetup',
+             '--batch-mode',
+             '--key-file', '-',
+             'open',
+             '--test-passphrase',
+             '/dev/sdb'],
+            input=b'mykey'
+        )
+
+    @mock.patch.object(dmcrypt.subprocess, 'check_output')
+    def test_luks_test_key_command_failure(self, _check_output):
+        _check_output.side_effect = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=['cryptsetup']
+        )
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            dmcrypt.luks_test_key('mykey', '/dev/sdb')
+
+        _check_output.assert_called_once_with(
+            ['cryptsetup',
+             '--batch-mode',
+             '--key-file', '-',
+             'open',
+             '--test-passphrase',
+             '/dev/sdb'],
+            input=b'mykey'
+        )
+
+    @mock.patch.object(dmcrypt, 'subprocess')
+    @mock.patch.object(dmcrypt, 'os')
+    def test_luks_add_key(self, _os, _subprocess):
+        _os.memfd_create.return_value = 10
+
+        dmcrypt.luks_add_key(
+            b'existing-key',
+            'new-key',
+            '/dev/sdb'
+        )
+
+        _os.memfd_create.assert_called_once_with(
+            'vaultlocker-existing-key'
+        )
+        _subprocess.check_output.assert_called_once_with(
+            ['cryptsetup',
+             '--batch-mode',
+             '--key-file', '/proc/self/fd/10',
+             '--new-keyfile', '-',
+             'luksAddKey', '/dev/sdb'],
+            input=b'new-key',
+            pass_fds=(10,)
+        )
+        _os.close.assert_called_once_with(10)
+
+    @mock.patch.object(dmcrypt, 'subprocess')
+    @mock.patch.object(dmcrypt, 'os')
+    def test_luks_add_key_failure_closes_fd(
+            self, _os, _subprocess):
+        _os.memfd_create.return_value = 10
+        _subprocess.check_output.side_effect = (
+            subprocess.CalledProcessError(
+                returncode=1,
+                cmd=['cryptsetup']
+            )
+        )
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            dmcrypt.luks_add_key(
+                'existing-key',
+                'new-key',
+                '/dev/sdb'
+            )
+        _subprocess.check_output.assert_called_once_with(
+            ['cryptsetup',
+             '--batch-mode',
+             '--key-file', '/proc/self/fd/10',
+             '--new-keyfile', '-',
+             'luksAddKey', '/dev/sdb'],
+            input=b'new-key',
+            pass_fds=(10,)
+        )
+        _os.close.assert_called_once_with(10)
 
     @mock.patch.object(dmcrypt, 'subprocess')
     def test_udevadm_rescan(self, _subprocess):

--- a/vaultlocker/tests/unit/test_vaultlocker.py
+++ b/vaultlocker/tests/unit/test_vaultlocker.py
@@ -376,6 +376,249 @@ class TestVaultlocker(base.TestCase):
             str(error.exception),
         )
 
+    @mock.patch.object(shell, 'sys')
+    def test_read_existing_key_from_piped_stdin(self, _sys):
+        _sys.stdin.isatty.return_value = False
+        _sys.stdin.buffer.read.return_value = b'existing-key'
+
+        self.assertEqual(
+            b'existing-key',
+            shell._read_existing_key(None),
+        )
+
+        _sys.stdin.buffer.read.assert_called_once_with()
+
+    @mock.patch.object(shell.getpass, 'getpass')
+    @mock.patch.object(shell, 'sys')
+    def test_read_existing_key_prompts_for_terminal_stdin(
+            self, _sys, _getpass):
+        _sys.stdin.isatty.return_value = True
+        _getpass.return_value = 'some'
+
+        self.assertEqual(
+            b'some',
+            shell._read_existing_key(None),
+        )
+
+        _getpass.assert_called_once_with(
+            'Existing LUKS passphrase: ',
+        )
+
+    @mock.patch('builtins.open', new_callable=mock.mock_open,
+                read_data=b'existing-key')
+    def test_read_existing_key_from_file(self, _open):
+        self.assertEqual(
+            b'existing-key',
+            shell._read_existing_key('/path/to/key'),
+        )
+
+        _open.assert_called_once_with('/path/to/key', 'rb')
+
+    @mock.patch.object(shell.dmcrypt, 'generate_key')
+    def test_get_or_create_managed_key_reuses_existing(
+            self, _generate_key):
+        store = mock.MagicMock()
+        store.read.return_value = {
+            'dmcrypt_key': 'managed-key',
+        }
+
+        self.assertEqual(
+            'managed-key',
+            shell._get_or_create_managed_key(
+                store,
+                'host/test-uuid',
+            ),
+        )
+
+        store.read.assert_called_once_with('host/test-uuid')
+        _generate_key.assert_not_called()
+
+    @mock.patch.object(shell, '_store_and_validate_key')
+    @mock.patch.object(shell.dmcrypt, 'generate_key')
+    def test_get_or_create_managed_key_creates_missing(
+            self, _generate_key, _store_and_validate_key):
+        store = mock.MagicMock()
+        store.read.side_effect = hvac.exceptions.InvalidPath(
+            'missing',
+        )
+        _generate_key.return_value = 'managed-key'
+
+        self.assertEqual(
+            'managed-key',
+            shell._get_or_create_managed_key(
+                store,
+                'host/test-uuid',
+            ),
+        )
+
+        _generate_key.assert_called_once_with()
+        _store_and_validate_key.assert_called_once_with(
+            store,
+            'host/test-uuid',
+            'managed-key',
+        )
+
+    @mock.patch.object(shell.dmcrypt, 'generate_key')
+    def test_get_or_create_managed_key_error(
+            self, _generate_key):
+        store = mock.MagicMock()
+        store.read.side_effect = hvac.exceptions.Forbidden(
+            'denied',
+        )
+
+        with self.assertRaises(hvac.exceptions.Forbidden):
+            shell._get_or_create_managed_key(
+                store,
+                'host/test-uuid',
+            )
+
+        _generate_key.assert_not_called()
+
+    @mock.patch.object(shell, '_device_exists', return_value=False)
+    @mock.patch.object(shell, '_get_or_create_managed_key')
+    @mock.patch.object(shell, 'get_hostname')
+    @mock.patch.object(shell, '_vault_store')
+    @mock.patch.object(shell, 'systemd')
+    @mock.patch.object(shell, 'dmcrypt')
+    def test_enroll_block_device(
+            self, _dmcrypt, _systemd, _vault_store,
+            _get_hostname, _get_managed_key, _device_exists):
+        _get_hostname.return_value = 'host'
+        _get_managed_key.return_value = 'managed-key'
+
+        _dmcrypt.luks_uuid.return_value = 'test-uuid'
+        _dmcrypt.luks_test_key.side_effect = [
+            True,
+            False,
+            True,
+        ]
+
+        args = mock.MagicMock()
+        args.block_device = ['/dev/sdb']
+        client = mock.MagicMock()
+
+        shell._enroll_block_device(
+            args,
+            client,
+            self.config,
+            b'existing-key',
+        )
+
+        _dmcrypt.luks_uuid.assert_called_once_with('/dev/sdb')
+        _dmcrypt.luks_test_key.assert_has_calls([
+            mock.call(b'existing-key', '/dev/sdb'),
+            mock.call('managed-key', '/dev/sdb'),
+            mock.call('managed-key', '/dev/sdb'),
+        ])
+        _get_managed_key.assert_called_once_with(
+            _vault_store.return_value,
+            'host/test-uuid',
+        )
+        _dmcrypt.luks_add_key.assert_called_once_with(
+            b'existing-key',
+            'managed-key',
+            '/dev/sdb',
+        )
+        _dmcrypt.luks_open.assert_called_once_with(
+            'managed-key',
+            'test-uuid',
+        )
+        _systemd.enable.assert_called_once_with(
+            'vaultlocker-decrypt@test-uuid.service',
+        )
+
+    @mock.patch.object(shell, '_device_exists', return_value=True)
+    @mock.patch.object(shell, '_get_or_create_managed_key')
+    @mock.patch.object(shell, 'get_hostname')
+    @mock.patch.object(shell, '_vault_store')
+    @mock.patch.object(shell, 'systemd')
+    @mock.patch.object(shell, 'dmcrypt')
+    def test_enroll_block_device_already_enrolled(
+            self, _dmcrypt, _systemd, _vault_store,
+            _get_hostname, _get_managed_key, _device_exists):
+        _get_hostname.return_value = 'host'
+        _get_managed_key.return_value = 'managed-key'
+
+        _dmcrypt.luks_uuid.return_value = 'test-uuid'
+        _dmcrypt.luks_test_key.side_effect = [
+            True,
+            True,
+        ]
+
+        args = mock.MagicMock()
+        args.block_device = ['/dev/sdb']
+
+        shell._enroll_block_device(
+            args,
+            mock.MagicMock(),
+            self.config,
+            b'existing-key',
+        )
+
+        _dmcrypt.luks_add_key.assert_not_called()
+        _dmcrypt.luks_open.assert_not_called()
+        _systemd.enable.assert_called_once_with(
+            'vaultlocker-decrypt@test-uuid.service',
+        )
+
+    @mock.patch.object(shell, '_get_or_create_managed_key')
+    @mock.patch.object(shell, '_vault_store')
+    @mock.patch.object(shell, 'systemd')
+    @mock.patch.object(shell, 'dmcrypt')
+    def test_enroll_block_device_rejects_invalid_existing_key(
+            self, _dmcrypt, _systemd, _vault_store,
+            _get_managed_key):
+        _dmcrypt.luks_uuid.return_value = 'test-uuid'
+        _dmcrypt.luks_test_key.return_value = False
+
+        args = mock.MagicMock()
+        args.block_device = ['/dev/sdb']
+
+        with self.assertRaises(ValueError) as error:
+            shell._enroll_block_device(
+                args,
+                mock.MagicMock(),
+                self.config,
+                b'wrong-key',
+            )
+
+        self.assertEqual(
+            'Existing key does not unlock /dev/sdb',
+            str(error.exception),
+        )
+        _vault_store.assert_not_called()
+        _get_managed_key.assert_not_called()
+        _dmcrypt.luks_add_key.assert_not_called()
+        _dmcrypt.luks_open.assert_not_called()
+        _systemd.enable.assert_not_called()
+
+    @mock.patch.object(
+        shell.sys,
+        'argv',
+        [
+            'vaultlocker',
+            'enroll',
+            '/dev/sdb',
+        ],
+    )
+    @mock.patch.object(shell, 'get_config')
+    @mock.patch.object(shell, 'enroll')
+    def test_main_parses_enroll(
+            self, _enroll, _get_config):
+        _get_config.return_value = self.config
+
+        shell.main()
+
+        _get_config.assert_called_once_with(
+            shell.DEFAULT_CONF_FILE,
+        )
+        _enroll.assert_called_once()
+
+        args, config = _enroll.call_args[0]
+        self.assertIsNone(args.existing_key_file)
+        self.assertEqual(['/dev/sdb'], args.block_device)
+        self.assertIs(self.config, config)
+
 
 class TestKVConfiguration(base.TestCase):
 


### PR DESCRIPTION
Add an enroll command that adds a Vaultlocker-managed key to an existing LUKS device.

The operator provides the existing LUKS passphrase through stdin or a file. Vaultlocker verifies the passphrase, generates and stores a managed key in Vault, and adds that key to the device. The existing passphrase remains valid and is not stored in Vault or on the host.

## Changes

- Add helpers for reading the LUKS UUID, testing a passphrase, and adding a key.
- Add the vaultlocker enroll command.
- Accept the existing passphrase through stdin or a file.
- Store the generated managed key at the LUKS UUID path in Vault.
- Reuse an existing managed key when enrollment is retried.
- Verify the managed key before opening the device.
- Open the encrypted device and enable its Vaultlocker systemd service.
- Add unit tests for the dm-crypt helpers and enrollment flow.

## Manual testing
Tested enrollment against a real vault deployment using a LUKS loop device.

- Confirmed that the managed key was added to the device.
- Confirmed that the original passphrase still unlocks the device.
- Confirmed that the encrypted mapping was opened and its correspondin systemd service was enabled.


# How to test

Pre-requisites
- A disposable LUKS device with a known passphrase
- Access to a test Vault deployment. (Examples: https://canonical-vault-charms.readthedocs-hosted.com/en/latest/tutorial/getting_started_k8s/ or https://developer.hashicorp.com/vault/tutorials/get-started/setup).
- A working /etc/vaultlocker/vaultlocker.conf with valid AppRole credentials
- This branch on the test host

Install the branch in a virtual environment: `pip install -e .`

Run enrollment:

`sudo <vaultlocker-bin-path> enroll /dev/<device>`

Verify that:

- A managed key is stored in Vault at the configured backend, hostname and luks uuid path.
- The original passphrase remains valid.
- A new LUKS keyslot is active.
- A systemd service was created with the luks uuid.

Jira: OPEN-4695