### PR TITLE
Fix configuration path handling in CLI

### DIFF
--- a/vaultlocker/shell.py
+++ b/vaultlocker/shell.py
@@ -373,7 +373,7 @@ def main():
         if (len(vars(args)) <= 2):
             parser.print_help()
         else:
-            args.func(args, get_config())
+            args.func(args, get_config(args.config))
     except Exception as e:
         raise SystemExit(
             '{prog}: {msg}'.format(


### PR DESCRIPTION
Pass the selected configuration path to `get_config`.

Change 1c569657c4a7ae82ad61fccf798e751a604150a0 called `get_config` without its required config_path argument, causing encrypt and decrypt commands to fail before reading the configuration.